### PR TITLE
Fix Docker error related to group membership

### DIFF
--- a/vagrant-docker/host/Vagrantfile
+++ b/vagrant-docker/host/Vagrantfile
@@ -23,6 +23,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "slowe/ubuntu-trusty-x64"
   config.vm.provision "docker"
 
+  # Kill SSH connection to Docker Host
+  # Workaround for Vagrant issue #3998 related to group memberships
+  config.vm.provision "shell", inline: "ps aux | grep 'sshd:' | awk '{print $2}' | xargs kill"
+
   # Disable synced folders (prevents an NFS error on "vagrant up")
   config.vm.synced_folder ".", "/vagrant", disabled: true
 end


### PR DESCRIPTION
Kill SSH connection to force re-connecting and updating group membership in order to correct Docker daemon error