### PR TITLE
terraform: Use Neutron floating IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .vagrant
 real-adminrc
 *.taskpaper
+terraform/tf-example/terraform.tfstate*

--- a/terraform/tf-example/main.tf
+++ b/terraform/tf-example/main.tf
@@ -22,7 +22,7 @@ resource "openstack_networking_router_interface_v2" "tf-router-interface" {
 	subnet_id = "${openstack_networking_subnet_v2.tf-subnet.id}"
 }
 
-resource "openstack_compute_floatingip_v2" "tf-fip" {
+resource "openstack_networking_floatingip_v2" "tf-fip" {
 	pool = "${var.pool}"
 	depends_on = ["openstack_networking_router_interface_v2.tf-router-interface"]
 }
@@ -33,7 +33,7 @@ resource "openstack_compute_instance_v2" "tf-instance" {
 	flavor_name = "${var.flavor}"
 	key_pair = "${var.key_pair}"
 	security_groups = ["default"]
-	floating_ip = "${openstack_compute_floatingip_v2.tf-fip.address}"
+	floating_ip = "${openstack_networking_floatingip_v2.tf-fip.address}"
 	network {
 		uuid = "${openstack_networking_network_v2.tf-net.id}"
 	}

--- a/terraform/tf-example/output.tf
+++ b/terraform/tf-example/output.tf
@@ -1,3 +1,3 @@
 output "address" {
-	value = "${openstack_compute_floatingip_v2.tf-fip.address}"
+	value = "${openstack_networking_floatingip_v2.tf-fip.address}"
 }

--- a/terraform/tf-example/provider.tf
+++ b/terraform/tf-example/provider.tf
@@ -2,5 +2,5 @@ provider "openstack" {
 	user_name = "demo"
 	tenant_name = "demo"
 	password = "password"
-	auth_url = "http://openstack.domain.net:5000/v2.0"
+	auth_url = "http://192.168.33.101:5000/v2.0"
 }

--- a/terraform/tf-example/provider.tf
+++ b/terraform/tf-example/provider.tf
@@ -2,5 +2,5 @@ provider "openstack" {
 	user_name = "demo"
 	tenant_name = "demo"
 	password = "password"
-	auth_url = "http://192.168.33.101:5000/v2.0"
+	auth_url = "http://openstack.domain.net:5000/v2.0"
 }


### PR DESCRIPTION
Use openstack_networking_floatingip_v2 instead of
openstack_compute_floatingip_v2 to make use of
Neutron floating IPs in the Terraform example.

Also update the .gitignore to ignore the terraform
DB which is generated.

Signed-off-by: Kyle Mestery <mestery@mestery.com>