### PR TITLE
Add Ruby code to all Vagrantfiles

### DIFF
--- a/docker-swarm-ha/Vagrantfile
+++ b/docker-swarm-ha/Vagrantfile
@@ -15,7 +15,7 @@ require 'erb'
 
 # Read YAML file with VM details (box, CPU, RAM, IP addresses)
 # Be sure to edit servers.yml to provide correct IP addresses
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Use template to create server-specific configuration files
 template = File.join(File.dirname(__FILE__), 'config.json.erb')

--- a/docker-swarm/Vagrantfile
+++ b/docker-swarm/Vagrantfile
@@ -16,7 +16,7 @@ USER_DATA = File.join(File.dirname(__FILE__), "user-data")
 
 # Read YAML file with VM details (box, CPU, RAM, IP addresses)
 # Be sure to edit servers.yml to provide correct IP addresses
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Create and configure the VMs
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/etcd-2.0/Vagrantfile
+++ b/etcd-2.0/Vagrantfile
@@ -11,7 +11,7 @@ require 'yaml'
 
 # Read YAML file with VM details (box, CPU, RAM, IP addresses)
 # Be sure to edit servers.yml to provide correct IP addresses
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Require 'erb' module
 require 'erb'

--- a/openstack-cli/Vagrantfile
+++ b/openstack-cli/Vagrantfile
@@ -10,7 +10,7 @@ ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
 require 'yaml'
 
 # Read YAML file with VM details (box, CPU, and RAM)
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Create and configure the VMs
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/photon-cloudinit/Vagrantfile
+++ b/photon-cloudinit/Vagrantfile
@@ -15,7 +15,7 @@ require 'yaml'
 
 # Read YAML file to get VM configuration information
 # Edit servers.yml to change VM configuration details
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Look for user-data and meta-data files in same directory
 USER_DATA = File.join(File.dirname(__FILE__), "user-data")

--- a/photon/Vagrantfile
+++ b/photon/Vagrantfile
@@ -11,7 +11,7 @@ require 'yaml'
 
 # Read YAML file to get VM configuration information
 # Edit servers.yml to change VM configuration details
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Create and configure the VMs
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/rkt/Vagrantfile
+++ b/rkt/Vagrantfile
@@ -10,7 +10,7 @@ ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
 require 'yaml'
 
 # Read YAML file with VM details (box, CPU, and RAM)
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Create and configure the VMs
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/swarm-etcd2-photon/Vagrantfile
+++ b/swarm-etcd2-photon/Vagrantfile
@@ -21,7 +21,7 @@ META_DATA = File.join(File.dirname(__FILE__), "meta-data")
 
 # Read YAML file with VM details (box, CPU, RAM, IP addresses)
 # Be sure to edit servers.yml to provide correct IP addresses
-servers = YAML.load_file('servers.yml')
+servers = YAML.load_file(File.join(File.dirname(__FILE__), 'servers.yml'))
 
 # Use config from YAML file to write out templates for etcd overrides
 template = File.join(File.dirname(__FILE__), 'etcd.defaults.erb')

--- a/vagrant-docker-yaml/Vagrantfile
+++ b/vagrant-docker-yaml/Vagrantfile
@@ -12,7 +12,7 @@ require 'yaml'
 
 # Read details of containers to be created from YAML file
 # Be sure to edit 'containers.yml' to provide container details
-containers = YAML.load_file('containers.yml')
+containers = YAML.load_file(File.join(File.dirname(__FILE__), 'containers.yml'))
 
 # Create and configure the Docker container(s)
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # to use default boot2docker box
   config.vm.provider "docker" do |docker|
     docker.vagrant_vagrantfile = "host/Vagrantfile"
-  end
+  end # config.vm.provider
 
   # Iterate through the entries in the YAML file
   containers.each do |container|
@@ -44,7 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         # Specify a friendly name for the Docker container, pull from YAML file
         docker.name = container["name"]
-      end
-    end
-  end
-end
+      end # contnr.vm.provider
+    end # config.vm.define
+  end # containers.each
+end # Vagrant.configure

--- a/vagrant-docker/Vagrantfile
+++ b/vagrant-docker/Vagrantfile
@@ -30,5 +30,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Specify a friendly name for the Docker container
     docker.name = 'nginx-container'
-  end
-end
+  end # config.vm.provider
+end # Vagrant.configure

--- a/vagrant-openstack-multi/Vagrantfile
+++ b/vagrant-openstack-multi/Vagrantfile
@@ -6,10 +6,10 @@ require 'vagrant-openstack-provider'
 require 'yaml'
 
 # Read YAML file with OpenStack credentials
-creds = YAML.load_file('credentials.yml')
+creds = YAML.load_file(File.join(File.dirname(__FILE__), 'credentials.yml'))
 
 # Read YAML file with instance information
-instances = YAML.load_file('instances.yml')
+instances = YAML.load_file(File.join(File.dirname(__FILE__), 'instances.yml'))
 
 # Specify Vagrant version, Vagrant API version, and Vagrant provider
 Vagrant.require_version '>= 1.6.0'

--- a/vagrant-openstack/Vagrantfile
+++ b/vagrant-openstack/Vagrantfile
@@ -6,8 +6,10 @@ require 'vagrant-openstack-provider'
 require 'yaml'
 
 # Read YAML file with OpenStack credentials
-creds = YAML.load_file('credentials.yml')
-instances = YAML.load_file('instances.yml')
+creds = YAML.load_file(File.join(File.dirname(__FILE__), 'credentials.yml'))
+
+# Read YAML file with instance information
+instances = YAML.load_file(File.join(File.dirname(__FILE__), 'instances.yml'))
 
 # Specify Vagrant version and Vagrant API version
 Vagrant.require_version '>= 1.6.0'


### PR DESCRIPTION
Add Ruby code to determine full path to supporting files referenced in all Vagrantfiles. This will allow more effective use of Vagrant commands when not in the same directory as the Vagrantfile.