### PR TITLE
Add files for Vagrant + Docker + JSON

### DIFF
--- a/vagrant-docker-json/README.md
+++ b/vagrant-docker-json/README.md
@@ -1,0 +1,23 @@
+# Running Multiple Docker Containers in Vagrant with JSON
+
+These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) to quickly and relatively easily launch multiple Docker ([http://www.docker.com](http://www.docker.com)) containers. The specifics of the Docker containers are specified in an external JSON file. The configuration was tested using Vagrant 1.8.1, VMware Fusion 8.1.0, and the Vagrant VMware plugin.
+
+## Contents
+
+* **containers.json**: This JSON file contains a list of the Docker containers and their properties for use by Vagrant. If you don't want to use the default values, you will need to edit this file to specify container friendly name, image, and exposed ports.
+
+* **host/Vagrantfile**: This file is used by Vagrant to spin up a "host VM" for use with the Vagrant Docker provider. Edit this file to change the Vagrant box you'd like to use; by default, this Vagrantfile uses the "slowe/ubuntu-trusty-x64" box (built for the "vmware_desktop" provider).
+
+* **README.md**: The file you're currently reading.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up the Docker containers on the host VM created by `host/Vagrantfile`. Unless you change filenames, you should not need to edit this file. All container details are stored in a separate JSON-encoded data file.
+
+## Instructions
+
+1. If you wish to use a box _other_ than my "ubuntu-trusty-x64" base box (running Ubuntu 14.04), edit the `Vagrantfile` in the `host` subdirectory.
+
+2. Edit the `containers.json` file to specify the Docker containers that Vagrant should create on the host VM (specified by `host/Vagrantfile`). Each container should contain three properties: `name` (the friendly name to be assigned to the Docker container), `image` (the name of the Docker image to be used for this container), and `ports` (a list of ports to be exposed for the container).
+
+3. From the directory where the main `Vagrantfile` is located, simply run `vagrant up` to spin up the specified host VM and specified Docker containers. Note that Internet access **will be** required to download Docker and the Docker images.
+
+Enjoy!

--- a/vagrant-docker-json/Vagrantfile
+++ b/vagrant-docker-json/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify Vagrant version, Vagrant API version, and Vagrant clone location
+Vagrant.require_version ">= 1.6.0"
+VAGRANTFILE_API_VERSION = "2"
+ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'docker'
+
+# Require 'json' module
+require 'json'
+
+# Read details of containers to be created from YAML file
+# Be sure to edit 'containers.yml' to provide container details
+containers = JSON.parse(File.read(File.join(File.dirname(__FILE__), 'containers.json')))
+
+# Create and configure the Docker container(s)
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Perform one-time configuration of Docker provider to specify
+  # location of Vagrantfile for host VM; comment out this section
+  # to use default boot2docker box
+  config.vm.provider "docker" do |docker|
+    docker.vagrant_vagrantfile = "host/Vagrantfile"
+  end # config.vm.provider
+
+  # Iterate through the entries in the YAML file
+  containers.each do |container|
+    config.vm.define container["name"] do |cntnr|
+
+      # Disable synced folders for the Docker container
+      # (prevents an NFS error on "vagrant up")
+      cntnr.vm.synced_folder ".", "/vagrant", disabled: true
+
+      # Configure the Docker provider for Vagrant
+      cntnr.vm.provider "docker" do |docker|
+
+        # Specify the Docker image to use, pull value from YAML file
+        docker.image = container["image"]
+
+        # Specify port mappings, pull value from YAML file
+        # If omitted, no ports are mapped!
+        docker.ports = container["ports"]
+
+        # Specify a friendly name for the Docker container, pull from YAML file
+        docker.name = container["name"]
+      end # contnr.vm.provider
+    end # config.vm.define
+  end # containers.each
+end # Vagrant.configure

--- a/vagrant-docker-json/containers.json
+++ b/vagrant-docker-json/containers.json
@@ -1,0 +1,13 @@
+[
+	{
+		"name": "nginx-01",
+		"image": "nginx",
+		"ports": ["80:80", "443:443"]
+	},
+
+	{
+		"name": "redis-01",
+		"image": "redis",
+		"ports": ["6379:6379"]
+	}
+]

--- a/vagrant-docker-json/host/Vagrantfile
+++ b/vagrant-docker-json/host/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify Vagrant version and Vagrant API version
+Vagrant.require_version ">= 1.6.0"
+VAGRANTFILE_API_VERSION = "2"
+
+# Create and configure the VM(s)
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Assign a friendly name to this host VM
+  config.vm.hostname = "docker-host"
+
+  # Skip checking for an updated Vagrant box
+  config.vm.box_check_update = false
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Spin up a "host box" for use with the Docker provider
+  # and then provision it with Docker
+  config.vm.box = "slowe/ubuntu-trusty-x64"
+  config.vm.provision "docker"
+
+  # Disable synced folders (prevents an NFS error on "vagrant up")
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+end


### PR DESCRIPTION
Add files for a multi-container environment using the Vagrant Docker provider and an external JSON data file. That includes a Vagrantfile, external JSON data file, host VM Vagrantfile, and README.md.