### PR TITLE
Add files for using cloud-init to customize CoreOS toolbox

### DIFF
--- a/coreos-cloudinit-toolbox/README.md
+++ b/coreos-cloudinit-toolbox/README.md
@@ -1,0 +1,57 @@
+# Customizing the CoreOS Toolbox using Cloud-Init
+
+These files were created to allow users to see how to use cloud-init ([http://cloudinit.readthedocs.org/](http://cloudinit.readthedocs.org/)) to customize the CoreOS ([https://coreos.com/](https://coreos.com/)) toolbox. There are three ways you can use this learning environment:
+
+* Users can use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) and a virtualization provider (such as VMware Fusion with the Vagrant VMware plugin) to spin up a local environment.
+* Users can spin up an instance in an existing OpenStack cloud.
+* Users can spin up an AWS instance.
+
+## Contents
+
+* **machines.yml**: This YAML file contains a list of VM definitions. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. You may need to edit this file to provide appropriate IP addresses and other VM configuration data (see "Instructions" below). This file is _not_ needed when testing with OpenStack or AWS intances.
+
+* **README.md**: This file you're currently reading.
+
+* **user-data**: This cloud-init configuration file should be able to be used unchanged, and is used by Vagrant, OpenStack, and AWS (see "Instructions") below.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up local VMs. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file. This file is _not_ needed when testing with OpenStack or AWS instances.
+
+## Instructions
+
+### Using Vagrant
+
+This section assumes you've already installed Vagrant and the necessary virtualization provider. Please refer to the documentation for those products for more information on installation or configuration. This was tested using Vagrant 1.8.1, VMware Fusion 8.1.0, and the Vagrant VMware plugin.
+
+1. Use `vagrant box add` to install the CoreOS Vagrant box. See [http://stable.release.core-os.net/amd64-usr/](http://stable.release.core-os.net/amd64-usr/) for downloads of the Vagrant box for the CoreOS Stable release channel. 
+
+2. Place the files from the `coreos-cloudinit-toolbox` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the the `coreos-cloudinit-toolbox` folder.
+
+3. Edit `machines.yml` file to provide the specific details on the VMs that Vagrant should create. The `Vagrantfile` expects five values for each VM: `name` (the user-friendly name of the VM, which will also be used as the hostname for the guest OS inside the VM); `box` (the name of the CoreOS Vagrant box downloaded in step #1); `ram` (the amount of memory to be assigned to the VM); `vcpu` (the number of vCPUs that should be assigned to the VM); and `ip_addr` (a private IP address to be statically assigned to the VM).
+
+4. If the box you downloaded in step #1 is named something _other_ than "coreos-stable", then edit `Vagrantfile` and change all instances of "coreos-stable" to match the name of the box you downloaded.
+
+5. Once you have edited `machines.yml` (and `Vagrantfile`, if necessary), use `vagrant up` to bring up the VMs (a single CoreOS VM, by default).
+
+6. Log into the VM using `vagrant ssh`. Once you're logged in, verify that `.toolboxrc` exists in the `core` user's home directory, and verify that `/opt/bin/python` exists. The presence of these two files shows that cloud-init worked properly. Optionally, feel free to run `python -i` and watch CoreOS download the appropriate Python container and drop you at a Python interpreter prompt.
+
+### Using OpenStack
+
+This section assumes that you have a functioning OpenStack cloud and that this cloud already has a CoreOS image for users to use. If this is _not_ the case, you'll need to upload a CoreOS image (or ask your cloud administrator to make one accessible). This was tested using OpenStack "Juno" on Ubuntu/KVM with VMware NSX providing the networking functionality.
+
+Because of wide variations in how OpenStack is configured and in how users consume OpenStack, this section provides only high-level directions as opposed to step-by-step instructions.
+
+* You'll need to supply the `user-data` file from the `coreos-cloudinit-toolbox` directory of the repository (or its contents) to OpenStack when launching your instance(s). In the Dashboard GUI, this is done via the "Post-Creation" tab of the Launch Instance wizard. When using the `nova boot` CLI command, this is done via the `--user-data` flag.
+
+* When you log into the running instance (note you may need to use an SSH bastion host or assign a floating IP to the instance), check for the existence of `.toolboxrc` in the `core` user's home directory and the existence of `/opt/bin/python`. Both of these files are created by cloud-init when OpenStack launches the instance. Optionally, feel free to run `python -i` and watch CoreOS download the appropriate Python container and drop you at a Python interpreter prompt.
+
+### Using AWS
+
+This section assumes you have an Amazon AWS account and are relatively familiar with launching instances on AWS. Due to wide variations in how users may consume AWS resources, this section provides only high-level directions.
+
+* Launch your instance in the desired AWS region. Refer to [https://coreos.com/os/docs/latest/booting-on-ec2.html](https://coreos.com/os/docs/latest/booting-on-ec2.html) for a list of the CoreOS AMIs for each AWS region.
+
+* If you're using the AWS Management Console, you'll need to supply the `user-data` file (or its contents) from the `coreos-cloudinit-toolbox` directory of the repository in step 3 (Configure Instance). This is found in the Advanced Details section. If you're using the AWS CLI, this is done with the `--user-data` flag to the `aws ec2 run-instances` command.
+
+* When you log into the running instance, check for the existence of `.toolboxrc` in the `core` user's home directory and the existence of `/opt/bin/python`. Both of these files are created by cloud-init when AWS launches the instance. Optionally, feel free to run `python -i` and watch CoreOS download the appropriate Python container and drop you at a Python interpreter prompt.
+
+Enjoy!

--- a/coreos-cloudinit-toolbox/Vagrantfile
+++ b/coreos-cloudinit-toolbox/Vagrantfile
@@ -1,0 +1,83 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify Vagrant version, Vagrant API version, and Vagrant clone location
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_fusion'
+ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
+#ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+#ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_appcatalyst'
+
+# Require 'yaml', 'fileutils', and 'erb' modules
+require 'yaml'
+require 'fileutils'
+require 'erb'
+
+# Look for user-data file to configure/customize CoreOS boxes
+# No changes should need to be made to this file
+USER_DATA = File.join(File.dirname(__FILE__), 'user-data')
+
+# Read YAML file with VM details (box, CPU, RAM, IP addresses)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+      srv.vm.hostname = machine['name']
+      srv.vm.box = machine['box']
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Assign additional private network
+      if machine['ip_addr'] != nil
+        srv.vm.network 'private_network', ip: machine['ip_addr']
+      end # if machine['ip_addr']
+
+      # Configure CoreOS-based VMs using cloud-init
+      if srv.vm.box == 'coreos-stable'
+        srv.vm.provision 'file', source: "#{USER_DATA}", destination: '/tmp/vagrantfile-user-data'
+        srv.vm.provision 'shell', inline: 'mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/', privileged: true
+      end # if srv.vm.box == 'coreos-stable'
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider :vmware_fusion do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider vmware_fusion
+
+      # Configure CPU & RAM per settings in machines.yml (AppCatalyst)
+      srv.vm.provider :vmware_appcatalyst do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        #vmw.vmx['guestos'] = 'other3xlinux-64'
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider vmware_appcatalyst
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider :virtualbox do |vb|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+      end # srv.vm.provider virtualbox
+    end # config.vm.define
+  end # machines.each
+end # Vagrant.configure

--- a/coreos-cloudinit-toolbox/machines.yml
+++ b/coreos-cloudinit-toolbox/machines.yml
@@ -1,0 +1,6 @@
+---
+- name: "coreos-01"
+  box: "coreos-stable"
+  ram: "512"
+  vcpu: "1"
+  ip_addr: 192.168.100.100

--- a/coreos-cloudinit-toolbox/user-data
+++ b/coreos-cloudinit-toolbox/user-data
@@ -1,0 +1,16 @@
+#cloud-config
+
+write_files:
+  - path: /home/core/.toolboxrc
+    owner: core
+    content: |
+        TOOLBOX_DOCKER_IMAGE=python
+        TOOLBOX_DOCKER_TAG=2.7.11-alpine
+        TOOLBOX_USER=root
+  - path: /opt/bin/python
+    owner: root:root
+    permissions: '0755'
+    content: |
+        #!/bin/bash
+
+        toolbox --bind=/home:/home python "$@"


### PR DESCRIPTION
Add Vagrantfile, machines.yml, and user-data for use with local Vagrant environment. Add README.md with instructions for using local Vagrant environment, OpenStack instances, or AWS instances.