### PR TITLE
Add final Vagrant multi-platform environment

### DIFF
--- a/vagrant-multi-platform/README.md
+++ b/vagrant-multi-platform/README.md
@@ -1,0 +1,25 @@
+# Generic Debian 8.0 ("Jessie") VM
+
+These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) to quickly and  easily spin up a generic Debian 8.0 ("Jessie") 64-bit VM. The configuration was tested using Vagrant 1.7.2, VMware Fusion 6.0.5, and the Vagrant VMware plugin.
+
+**NOTE:** There's really nothing special here; I created these files because I often had a need to quickly and easily spin up a generic Debian VM for some purpose (building a package or testing a command). I'm including them here just for the sake of completeness.
+
+## Contents
+
+* **README.md**: This file you're currently reading.
+
+* **servers.yml**: This YAML file contains a list of VM definitions and associated configuration data. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
+
+## Instructions
+
+These instructions assume you've already installed VMware Fusion, Vagrant, and the Vagrant VMware plugin. Please refer to the documentation for those products for more information on installation or configuration.
+
+1. Use `vagrant box add` to add a 64-bit Debian 8.0 ("Jessie") base box to be used by this `Vagrantfile`. You'll need to specify a box that provides support for the `vmware_desktop` provider (it should work with either VMware Workstation or VMware Fusion).
+
+2. Edit the `servers.yml` file to ensure the box you downloaded in step 1 is specified on the "box:" line of this file.
+
+3. Run `vagrant up`, and when the VM is up use `vagrant ssh` to access the generic Debian VM.
+
+Enjoy!

--- a/vagrant-multi-platform/README.md
+++ b/vagrant-multi-platform/README.md
@@ -1,25 +1,34 @@
-# Generic Debian 8.0 ("Jessie") VM
+# Multi-Platform Vagrant Environment
 
-These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) to quickly and  easily spin up a generic Debian 8.0 ("Jessie") 64-bit VM. The configuration was tested using Vagrant 1.7.2, VMware Fusion 6.0.5, and the Vagrant VMware plugin.
+These files were created to test a method of providing a single Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) environment that could support multiple local virtualization platforms without any changes to the `Vagrantfile` or supporting configuration files. This configuration was tested with the following components:
 
-**NOTE:** There's really nothing special here; I created these files because I often had a need to quickly and easily spin up a generic Debian VM for some purpose (building a package or testing a command). I'm including them here just for the sake of completeness.
+* Vagrant 1.7.4 with VirtualBox 4.3.36 on Debian "Jessie" using the official "debian/jessie64" Vagrant box
+* Vagrant 1.8.1 with VMware Fusion 8.1.0 on OS X 10.11.3 using my self-built "slowe/debian-81-x64" Vagrant box
 
 ## Contents
 
-* **README.md**: This file you're currently reading.
+* **machines.yml**: This YAML file contains a list of VM definitions and associated configuration data. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. Separate box definitions are included: "vb_box" for VirtualBox, "vmw_box" for VMware Fusion.
 
-* **servers.yml**: This YAML file contains a list of VM definitions and associated configuration data. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs.
+* **README.md**: This file you're currently reading.
 
 * **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
 
+* **vbrc**: This file simply sets the "DEFAULT_VAGRANT_PROVIDER" environment variable to "virtualbox". Use the `source` command to pull in this definition on systems running VirtualBox **before** using any Vagrant commands.
+
+* **vmwrc**: This file simply sets the "DEFAULT_VAGRANT_PROVIDER" environment variable to "vmware_fusion". Use the `source` command to pull in this definition on systems running VMware Fusion **before** using any Vagrant commands.
+
 ## Instructions
 
-These instructions assume you've already installed VMware Fusion, Vagrant, and the Vagrant VMware plugin. Please refer to the documentation for those products for more information on installation or configuration.
+These instructions assume you've already installed Vagrant, the necessary back-end virtualization provider(s) (only VirtualBox and VMware Fusion are supported by this testing environment), and any necessary plugins. Please refer to the documentation for those products for more information on installation or configuration.
 
-1. Use `vagrant box add` to add a 64-bit Debian 8.0 ("Jessie") base box to be used by this `Vagrantfile`. You'll need to specify a box that provides support for the `vmware_desktop` provider (it should work with either VMware Workstation or VMware Fusion).
+1. Use `vagrant box add` to add a VirtualBox box and/or a VMware Fusion box (any box marked with "vmware_desktop" provider will work with Fusion). If you have both VMware Fusion and VirtualBox installed on the same system, install a box for both platforms.
 
-2. Edit the `servers.yml` file to ensure the box you downloaded in step 1 is specified on the "box:" line of this file.
+2. Edit the `machines.yml` file to ensure the box(es) you downloaded in step 1 is/are specified in this file. Place the name of the VirtualBox box as the value for "vb_box"; supply the name of the VMware Fusion box as the value for "vmw_box".
 
-3. Run `vagrant up`, and when the VM is up use `vagrant ssh` to access the generic Debian VM.
+3. Run `source vbrc` (to use VirtualBox) or `source vmwrc` (to use VMware Fusion).
+
+4. Run `vagrant up`. Vagrant will create the VM using the box specified in `machines.yml`, selecting the appropriate box based on the value of the environment variable.
+
+5. For ideal results, test this environment on different systems with different providers (i.e., a Linux system running VirtualBox and an OS X system running VMware Fusion). You'll see that, aside from the environment variables, no changes are required to either `Vagrantfile` or `machines.yml`.
 
 Enjoy!

--- a/vagrant-multi-platform/Vagrantfile
+++ b/vagrant-multi-platform/Vagrantfile
@@ -1,12 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Specify Vagrant version, Vagrant API version, and Vagrant clone location
-Vagrant.require_version ">= 1.6.0"
-VAGRANTFILE_API_VERSION = "2"
-ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_fusion'
-ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
-#ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+# Specify Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
 
 # Require 'yaml' module
 require 'yaml'
@@ -22,27 +19,34 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Iterate through entries in YAML file to create VMs
   machines.each do |machine|
-    config.vm.define machine["name"] do |srv|
+    config.vm.define machine['name'] do |srv|
 
       # Don't check for box updates
       srv.vm.box_check_update = false
-      srv.vm.hostname = machine["name"]
-      platform = "box." + ENV['VAGRANT_DEFAULT_PROVIDER']
-      srv.vm.box = machine[platform]
+      srv.vm.hostname = machine['name']
+
+      # Specify box based on default provider environment variable
+      if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'vmware_fusion'
+        srv.vm.box = machine['vmw_box']
+      elsif ENV['VAGRANT_DEFAULT_PROVIDER'] == 'virtualbox'
+        srv.vm.box = machine['vb_box']
+      else
+      	srv.vm.box = nil
+      end # if ENV['VAGRANT_DEFAULT_PROVIDER']
 
       # Disable default synced folder
-      srv.vm.synced_folder ".", "/vagrant", disabled: true
+      srv.vm.synced_folder '.', '/vagrant', disabled: true
 
       # Configure VMs with RAM and CPUs per machines.yml (Fusion)
-      srv.vm.provider :vmware_fusion do |vmw|
-        vmw.vmx["memsize"] = machine["ram"]
-        vmw.vmx["numvcpus"] = machine["vcpu"]
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
       end # srv.vm.provider vmware_fusion
 
       # Configure the VM with RAM and CPUs per machines.yml (VirtualBox)
-      srv.vm.provider :virtualbox do |vb|
-        vb.memory = machine["ram"]
-        vb.cpus = machine["vcpu"]
+      srv.vm.provider 'virtualbox' do |vb|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
       end # srv.vm.provider virtualbox
     end # config.vm.define
   end # machines.each

--- a/vagrant-multi-platform/Vagrantfile
+++ b/vagrant-multi-platform/Vagrantfile
@@ -1,0 +1,49 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify Vagrant version, Vagrant API version, and Vagrant clone location
+Vagrant.require_version ">= 1.6.0"
+VAGRANTFILE_API_VERSION = "2"
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_fusion'
+ENV['VAGRANT_VMWARE_CLONE_DIRECTORY'] = '~/.vagrant'
+#ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, and RAM)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+    config.vm.define machine["name"] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+      srv.vm.hostname = machine["name"]
+      platform = "box." + ENV['VAGRANT_DEFAULT_PROVIDER']
+      srv.vm.box = machine[platform]
+
+      # Disable default synced folder
+      srv.vm.synced_folder ".", "/vagrant", disabled: true
+
+      # Configure VMs with RAM and CPUs per machines.yml (Fusion)
+      srv.vm.provider :vmware_fusion do |vmw|
+        vmw.vmx["memsize"] = machine["ram"]
+        vmw.vmx["numvcpus"] = machine["vcpu"]
+      end # srv.vm.provider vmware_fusion
+
+      # Configure the VM with RAM and CPUs per machines.yml (VirtualBox)
+      srv.vm.provider :virtualbox do |vb|
+        vb.memory = machine["ram"]
+        vb.cpus = machine["vcpu"]
+      end # srv.vm.provider virtualbox
+    end # config.vm.define
+  end # machines.each
+end # Vagrant.configure

--- a/vagrant-multi-platform/machines.yml
+++ b/vagrant-multi-platform/machines.yml
@@ -1,0 +1,7 @@
+---
+- name: jessie
+  box:
+    vmware_fusion: slowe/debian-81-x64
+    virtualbox: debian/jessie64
+  ram: 1024
+  vcpu: 1

--- a/vagrant-multi-platform/machines.yml
+++ b/vagrant-multi-platform/machines.yml
@@ -1,7 +1,6 @@
 ---
 - name: jessie
-  box:
-    vmware_fusion: slowe/debian-81-x64
-    virtualbox: debian/jessie64
-  ram: 1024
+  vmw_box: slowe/debian-81-x64
+  vb_box: debian/jessie64
+  ram: 512
   vcpu: 1

--- a/vagrant-multi-platform/vbrc
+++ b/vagrant-multi-platform/vbrc
@@ -1,0 +1,1 @@
+export VAGRANT_DEFAULT_PROVIDER=virtualbox

--- a/vagrant-multi-platform/vmwrc
+++ b/vagrant-multi-platform/vmwrc
@@ -1,0 +1,1 @@
+export VAGRANT_DEFAULT_PROVIDER=vmware_fusion


### PR DESCRIPTION
Add a learning/testing environment that supports the use of Vagrant on multiple platforms and with multiple virtualization providers with _no_ changes to the `Vagrantfile`.