### PR TITLE
Add new environment for working with multiple OVS bridges

### DIFF
--- a/ovs-multi-br/README.md
+++ b/ovs-multi-br/README.md
@@ -1,0 +1,23 @@
+# Open vSwitch Multi-Bridge Configuration
+
+These files were created to test a method of providing a single Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) environment that enables easier experimentation with Open vSwitch (OVS) configurations leveraging multiple OVS bridges. This environment was tested using Vagrant 1.8.1 with VMware Fusion 8.1.0 on OS X 10.11.3 using my self-built "slowe/ubuntu-trusty-x64" Vagrant box.
+
+## Contents
+
+* **ansible.cfg**: This Ansible configuration file instructs Ansible to use the Vagrant-generated inventory file (by default in `./.vagrant/provisioners/inventory/vagrant_ansible_inventory`), to use the default vagrant user (`vagrant`) and default insecure Vagrant SSH private key.
+
+* **br0.xml** and **br1.xml**: These XML files are used to define a couple OVS-based Libvirt networks. No edits are necessary to this file.
+
+* **machines.yml**: This YAML file contains a list of VM definitions and associated configuration data. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. Separate box definitions are included: "vb_box" for VirtualBox, "vmw_box" for VMware Fusion.
+
+* **provision.yml**: This YAML file is an Ansible playbook that configures the VMs created by Vagrant when they are first provisioned. Ansible is called automatically by Vagrant; you do not need to invoke Ansible separately. No changes are needed to this file.
+
+* **README.md**: This file you're currently reading.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
+
+## Instructions
+
+These instructions assume you've already installed Vagrant, the necessary back-end virtualization provider(s) (only VirtualBox and VMware Fusion are supported by this testing environment), and any necessary plugins. Please refer to the documentation for those products for more information on installation or configuration.
+
+**INSTRUCTIONS NOT YET COMPLETE**

--- a/ovs-multi-br/Vagrantfile
+++ b/ovs-multi-br/Vagrantfile
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, and RAM)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+      srv.vm.hostname = machine['name']
+
+      # Set box to VMware Fusion box by default
+      srv.vm.box = machine['vmw_box']
+
+      # Disable default synced folder
+      srv.vm.synced_folder '.', '/vagrant', disabled: true
+
+      # Assign additional network if machine is noted as hypervisor
+      if machine['hypervisor'] == true
+        srv.vm.network 'private_network', ip: '192.168.101.2'
+        srv.vm.network 'private_network', ip: '192.168.102.2'
+      end # if machine['hypervisor']
+
+      # Configure VMs with RAM and CPUs per machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['hypervisor'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end # if machine['hypervisor']
+      end # srv.vm.provider vmware_fusion
+
+      # Configure the VM with RAM and CPUs per machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['vb_box']
+      end # srv.vm.provider virtualbox
+
+      # Provision with Ansible
+      config.vm.provision 'ansible' do |ansible|
+        ansible.playbook = 'provision.yml'
+      end # config.vm.provision
+    end # config.vm.define
+  end # machines.each
+end # Vagrant.configure

--- a/ovs-multi-br/ansible.cfg
+++ b/ovs-multi-br/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = ./.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
+private_key_file = ~/.vagrant.d/insecure_private_key
+remote_user = vagrant
+host_key_checking = False

--- a/ovs-multi-br/br0.xml
+++ b/ovs-multi-br/br0.xml
@@ -1,0 +1,6 @@
+<network>
+  <name>br0</name>
+  <forward mode='bridge'/>
+  <bridge name='br0'/>
+  <virtualport type='openvswitch'/>
+</network>

--- a/ovs-multi-br/br1.xml
+++ b/ovs-multi-br/br1.xml
@@ -1,0 +1,6 @@
+<network>
+  <name>br1</name>
+  <forward mode='bridge'/>
+  <bridge name='br1'/>
+  <virtualport type='openvswitch'/>
+</network>

--- a/ovs-multi-br/machines.yml
+++ b/ovs-multi-br/machines.yml
@@ -1,0 +1,7 @@
+---
+- name: hv-01
+  vmw_box: slowe/ubuntu-trusty-x64
+  vb_box: ubuntu/trusty64
+  ram: 1024
+  vcpu: 1
+  hypervisor: true

--- a/ovs-multi-br/provision.yml
+++ b/ovs-multi-br/provision.yml
@@ -1,0 +1,66 @@
+---
+- hosts: "all"
+  become: "yes"
+  remote_user: "vagrant"
+
+  tasks:
+  - name: "Install KVM, Libvirt, and OVS"
+    apt:
+      state: "present"
+      update_cache: "yes"
+      name: "{{ item }}"
+    with_items:
+      - "qemu-kvm"
+      - "libvirt-bin"
+      - "openvswitch-common"
+      - "openvswitch-switch"
+      - "virtinst"
+
+  - name: "Configure eth1 interface"
+    command: "ip addr flush dev eth1"
+
+  - name: "Configure eth2 interface"
+    command: "ip addr flush dev eth2"
+
+  - name: "Create OVS bridges"
+    openvswitch_bridge:
+      bridge: "{{ item }}"
+      state: "present"
+    with_items:
+      - "br0"
+      - "br1"
+
+  - name: "Configure OVS bridge br0"
+    openvswitch_port:
+      bridge: "br0"
+      port: "eth1"
+      state: "present"
+
+  - name: "Configure OVS bridge br1"
+    openvswitch_port:
+      bridge: "br1"
+      port: "eth2"
+      state: "present"
+
+  - name: "Download Cirros image"
+    get_url:
+      url: "https://download.cirros-cloud.net/0.3.2/cirros-0.3.2-x86_64-disk.img"
+      dest: "/home/vagrant/cirros-0.3.2-x86_64-disk.img"
+      validate_certs: "no"
+
+  - name: "Set file permissions"
+    file:
+      path: "/home/vagrant/cirros-0.3.2-x86_64-disk.img"
+      owner: "vagrant"
+      group: "vagrant"
+      mode: "0644"
+
+  - name: "Copy libvirt network definitions"
+    copy:
+      src: "{{ item }}"
+      dest: "/home/vagrant/"
+      owner: "vagrant"
+      group: "vagrant"
+    with_items:
+      - "br0.xml"
+      - "br1.xml"


### PR DESCRIPTION
Add Libvirt XML definitions, Ansible configuration file and playbook, YAML data file, README, and Vagrantfile for an environment enabling users to easily experiment with multi-bridge OVS configurations. Instructions are not yet fully complete. Also tracking a potential bug in the openvswitch_port Ansible module used (see https://github.com/ansible/ansible-modules-extras/issues/2500).