### PR TITLE
Add a Terraform configuration for creating a new VPC

### DIFF
--- a/terraform-aws/new-vpc/data.tf
+++ b/terraform-aws/new-vpc/data.tf
@@ -1,0 +1,18 @@
+data "aws_ami" "coreos_stable" {
+    filter {
+        name                = "root-device-type"
+        values              = ["ebs"]
+    }
+    filter {
+        name                = "architecture"
+        values              = ["x86_64"]
+    }
+    filter {
+        name                = "virtualization-type"
+        values              = ["hvm"]
+    }
+    filter {
+        name                = "name"
+        values              = ["*1185.3.0*"]
+    }
+}

--- a/terraform-aws/new-vpc/main.tf
+++ b/terraform-aws/new-vpc/main.tf
@@ -1,0 +1,80 @@
+# Create a new VPC
+resource "aws_vpc" "coreos_vpc" {
+    cidr_block              = "10.1.0.0/16"
+    enable_dns_hostnames    = "true"
+    enable_dns_support      = "true"
+    tags {
+        tool                = "terraform"
+    }
+}
+
+# Create a subnet in the new VPC
+resource "aws_subnet" "coreos_subnet" {
+    vpc_id                  = "${aws_vpc.coreos_vpc.id}"
+    cidr_block              = "10.1.1.0/24"
+    map_public_ip_on_launch = "true"
+    tags {
+        tool                = "terraform"
+    }
+}
+
+# Create a new security group
+resource "aws_security_group" "allow_inbound_ssh" {
+    vpc_id                  = "${aws_vpc.coreos_vpc.id}"
+    name                    = "allow-inbound-ssh"
+    description             = "Allows inbound SSH"
+    ingress {
+        from_port           = "22"
+        to_port             = "22"
+        protocol            = "tcp"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port           = "0"
+        to_port             = "0"
+        protocol            = "-1"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    tags {
+        tool                = "terraform"
+    }
+}
+
+# Create a new Internet gateway
+resource "aws_internet_gateway" "coreos_gw" {
+    vpc_id                  = "${aws_vpc.coreos_vpc.id}"
+    tags {
+        tool                = "terraform"
+    }
+}
+
+# Create a route table for the new VPC
+resource "aws_route_table" "coreos_vpc_rt" {
+    vpc_id                  = "${aws_vpc.coreos_vpc.id}"
+    route {
+        cidr_block          = "0.0.0.0/0"
+        gateway_id          = "${aws_internet_gateway.coreos_gw.id}"
+    }
+    tags {
+        tool                = "terraform"
+    }
+}
+
+# Associate route table with subnet in VPC
+resource "aws_route_table_association" "coreos_vpc_rta" {
+    subnet_id               = "${aws_subnet.coreos_subnet.id}"
+    route_table_id          = "${aws_route_table.coreos_vpc_rt.id}"
+}
+
+# Launch a new CoreOS instance in the new subnet and VPC
+resource "aws_instance" "coreos01" {
+    ami                     = "${data.aws_ami.coreos_stable.id}"
+    instance_type           = "${var.flavor}"
+    key_name                = "${var.keypair}"
+    vpc_security_group_ids  = ["${aws_security_group.allow_inbound_ssh.id}"]
+    subnet_id               = "${aws_subnet.coreos_subnet.id}"
+    depends_on              = ["aws_internet_gateway.coreos_gw"]
+    tags {
+        tool                = "terraform"
+    }
+}

--- a/terraform-aws/new-vpc/provider.tf
+++ b/terraform-aws/new-vpc/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region                  = "us-west-2"
+}

--- a/terraform-aws/new-vpc/vars.tf
+++ b/terraform-aws/new-vpc/vars.tf
@@ -1,0 +1,11 @@
+variable "keypair" {
+    type                    = "string"
+    description             = "AWS SSH keypair to use to connect to instances"
+    default                 = "aws_rsa"
+}
+
+variable "flavor" {
+    type                    = "string"
+    description             = "AWS type to use when creating instances"
+    default                 = "t2.micro"
+}


### PR DESCRIPTION
Add an example Terraform configuration for launching an instance in a new VPC. This includes creating a new VPC, a new subnet, a new Internet gateway, a new route table, and a new route table association (all required when creating a new VPC).