### PR TITLE
Add learning environment to show Terraform building an SSH bastion host on AWS

### DIFF
--- a/terraform/aws/bastion-aws/data.tf
+++ b/terraform/aws/bastion-aws/data.tf
@@ -1,0 +1,13 @@
+data "aws_ami" "atomic_ami" {
+    filter {
+        name                = "name"
+        values              = ["*CentOS Atomic*1701*"]
+    }
+}
+
+data "aws_ami" "centos_ami" {
+    filter {
+        name                = "name"
+        values              = ["*CentOS 7.3.1611*"]
+    }
+}

--- a/terraform/aws/bastion-aws/data.tf
+++ b/terraform/aws/bastion-aws/data.tf
@@ -1,13 +1,25 @@
 data "aws_ami" "atomic_ami" {
+    most_recent             = true
+    owners                  = ["410186602215"]
     filter {
         name                = "name"
-        values              = ["*CentOS Atomic*1701*"]
+        values              = ["CentOS Atomic Host 7*"]
+    }
+    filter {
+        name                = "virtualization-type"
+        values              = ["hvm"]
     }
 }
 
 data "aws_ami" "centos_ami" {
+    most_recent             = true
+    owners                  = ["410186602215"]
     filter {
         name                = "name"
-        values              = ["*CentOS 7.3.1611*"]
+        values              = ["CentOS Linux 7*"]
+    }
+    filter {
+        name                = "virtualization-type"
+        values              = ["hvm"]
     }
 }

--- a/terraform/aws/bastion-aws/instances.tf
+++ b/terraform/aws/bastion-aws/instances.tf
@@ -1,0 +1,30 @@
+# Launch a CentOS 7 instance to serve as bastion host
+resource "aws_instance" "bastion" {
+    ami                         = "${data.aws_ami.centos_ami.id}"
+    instance_type               = "${var.flavor}"
+    key_name                    = "${var.keypair}"
+    vpc_security_group_ids      = ["${aws_security_group.bastion_sg.id}"]
+    subnet_id                   = "${aws_subnet.bastion_net.id}"
+    depends_on                  = ["aws_internet_gateway.bastion_gw"]
+    tags {
+        tool                    = "terraform"
+        demo                    = "bastion-aws"
+        area                    = "instances"
+    }
+}
+
+# Launch a second CentOS instance to serve as a remote host
+resource "aws_instance" "remote" {
+    ami                         = "${data.aws_ami.centos_ami.id}"
+    instance_type               = "${var.flavor}"
+    key_name                    = "${var.keypair}"
+    vpc_security_group_ids      = ["${aws_security_group.remote_sg.id}"]
+    subnet_id                   = "${aws_subnet.bastion_net.id}"
+    depends_on                  = ["aws_internet_gateway.bastion_gw"]
+    associate_public_ip_address = false
+    tags {
+        tool                    = "terraform"
+        demo                    = "bastion-aws"
+        area                    = "instances"
+    }
+}

--- a/terraform/aws/bastion-aws/instances.tf
+++ b/terraform/aws/bastion-aws/instances.tf
@@ -7,22 +7,24 @@ resource "aws_instance" "bastion" {
     subnet_id                   = "${aws_subnet.bastion_net.id}"
     depends_on                  = ["aws_internet_gateway.bastion_gw"]
     tags {
+        Name                    = "bastion"
         tool                    = "terraform"
         demo                    = "bastion-aws"
         area                    = "instances"
     }
 }
 
-# Launch a second CentOS instance to serve as a remote host
-resource "aws_instance" "remote" {
-    ami                         = "${data.aws_ami.centos_ami.id}"
+# Launch a CentOS Atomic Host instance to serve as a private host
+resource "aws_instance" "private" {
+    ami                         = "${data.aws_ami.atomic_ami.id}"
     instance_type               = "${var.flavor}"
     key_name                    = "${var.keypair}"
-    vpc_security_group_ids      = ["${aws_security_group.remote_sg.id}"]
-    subnet_id                   = "${aws_subnet.bastion_net.id}"
+    vpc_security_group_ids      = ["${aws_security_group.private_sg.id}"]
+    subnet_id                   = "${aws_subnet.private_net.id}"
     depends_on                  = ["aws_internet_gateway.bastion_gw"]
     associate_public_ip_address = false
     tags {
+        Name                    = "private"
         tool                    = "terraform"
         demo                    = "bastion-aws"
         area                    = "instances"

--- a/terraform/aws/bastion-aws/networking.tf
+++ b/terraform/aws/bastion-aws/networking.tf
@@ -1,8 +1,8 @@
 # Create a new VPC
 resource "aws_vpc" "bastion_vpc" {
     cidr_block              = "10.2.0.0/16"
-    enable_dns_hostnames    = "true"
-    enable_dns_support      = "true"
+    enable_dns_hostnames    = true
+    enable_dns_support      = true
     tags {
         tool                = "terraform"
         demo                = "bastion-aws"
@@ -14,7 +14,19 @@ resource "aws_vpc" "bastion_vpc" {
 resource "aws_subnet" "bastion_net" {
     vpc_id                  = "${aws_vpc.bastion_vpc.id}"
     cidr_block              = "10.2.1.0/24"
-    map_public_ip_on_launch = "true"
+    map_public_ip_on_launch = true
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "networking"
+    }
+}
+
+# Create a private subnet in the new VPC
+resource "aws_subnet" "private_net" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    cidr_block              = "10.2.2.0/24"
+    map_public_ip_on_launch = false
     tags {
         tool                = "terraform"
         demo                = "bastion-aws"

--- a/terraform/aws/bastion-aws/networking.tf
+++ b/terraform/aws/bastion-aws/networking.tf
@@ -1,0 +1,53 @@
+# Create a new VPC
+resource "aws_vpc" "bastion_vpc" {
+    cidr_block              = "10.2.0.0/16"
+    enable_dns_hostnames    = "true"
+    enable_dns_support      = "true"
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "networking"
+    }
+}
+
+# Create a public subnet in the new VPC
+resource "aws_subnet" "bastion_net" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    cidr_block              = "10.2.1.0/24"
+    map_public_ip_on_launch = "true"
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "networking"
+    }
+}
+
+# Create a new Internet gateway
+resource "aws_internet_gateway" "bastion_gw" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "networking"
+    }
+}
+
+# Create a route table for the new VPC
+resource "aws_route_table" "bastion_routes" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    route {
+        cidr_block          = "0.0.0.0/0"
+        gateway_id          = "${aws_internet_gateway.bastion_gw.id}"
+    }
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "networking"
+    }
+}
+
+# Associate route table with subnet in VPC
+resource "aws_route_table_association" "bastion_rt_assoc" {
+    subnet_id               = "${aws_subnet.bastion_net.id}"
+    route_table_id          = "${aws_route_table.bastion_routes.id}"
+}

--- a/terraform/aws/bastion-aws/output.tf
+++ b/terraform/aws/bastion-aws/output.tf
@@ -7,5 +7,5 @@ output "bastion_priv_ip" {
 }
 
 output "remote_priv_ip" {
-    value = ["${aws_instance.remote.private_ip}"]
+    value = ["${aws_instance.private.private_ip}"]
 }

--- a/terraform/aws/bastion-aws/output.tf
+++ b/terraform/aws/bastion-aws/output.tf
@@ -1,0 +1,11 @@
+output "bastion_pub_ip" {
+    value = ["${aws_instance.bastion.public_ip}"]
+}
+
+output "bastion_priv_ip" {
+    value = ["${aws_instance.bastion.private_ip}"]
+}
+
+output "remote_priv_ip" {
+    value = ["${aws_instance.remote.private_ip}"]
+}

--- a/terraform/aws/bastion-aws/provider.tf
+++ b/terraform/aws/bastion-aws/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region                  = "us-west-2"
+}

--- a/terraform/aws/bastion-aws/security.tf
+++ b/terraform/aws/bastion-aws/security.tf
@@ -1,0 +1,59 @@
+# Create a security group to allow web traffic to remote host
+resource "aws_security_group" "remote_sg" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    name                    = "remote-sg"
+    description             = "Security group for web traffic to remote hosts"
+    ingress {
+        from_port           = "80"
+        to_port             = "80"
+        protocol            = "tcp"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port           = "443"
+        to_port             = "443"
+        protocol            = "tcp"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port           = "22"
+        to_port             = "22"
+        protocol            = "tcp"
+        cidr_blocks         = ["${aws_vpc.bastion_vpc.cidr_block}"]
+    }
+    egress {
+        from_port           = "0"
+        to_port             = "0"
+        protocol            = "-1"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "security"
+    }
+}
+
+# Create a security group to allow inbound SSH (for bastion only)
+resource "aws_security_group" "bastion_sg" {
+    vpc_id                  = "${aws_vpc.bastion_vpc.id}"
+    name                    = "bastion-sg"
+    description             = "Security group for SSH bastion host"
+    ingress {
+        from_port           = "22"
+        to_port             = "22"
+        protocol            = "tcp"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+     egress {
+        from_port           = "0"
+        to_port             = "0"
+        protocol            = "-1"
+        cidr_blocks         = ["0.0.0.0/0"]
+    }
+    tags {
+        tool                = "terraform"
+        demo                = "bastion-aws"
+        area                = "security"
+    }
+}

--- a/terraform/aws/bastion-aws/security.tf
+++ b/terraform/aws/bastion-aws/security.tf
@@ -1,25 +1,13 @@
-# Create a security group to allow web traffic to remote host
-resource "aws_security_group" "remote_sg" {
+# Create a security group to allow SSH traffic to private host(s) only from bastion
+resource "aws_security_group" "private_sg" {
     vpc_id                  = "${aws_vpc.bastion_vpc.id}"
-    name                    = "remote-sg"
-    description             = "Security group for web traffic to remote hosts"
-    ingress {
-        from_port           = "80"
-        to_port             = "80"
-        protocol            = "tcp"
-        cidr_blocks         = ["0.0.0.0/0"]
-    }
-    ingress {
-        from_port           = "443"
-        to_port             = "443"
-        protocol            = "tcp"
-        cidr_blocks         = ["0.0.0.0/0"]
-    }
+    name                    = "private-sg"
+    description             = "Security group for web traffic to private hosts"
     ingress {
         from_port           = "22"
         to_port             = "22"
         protocol            = "tcp"
-        cidr_blocks         = ["${aws_vpc.bastion_vpc.cidr_block}"]
+        cidr_blocks         = ["10.2.1.0/24"]
     }
     egress {
         from_port           = "0"

--- a/terraform/aws/bastion-aws/ssh.cfg
+++ b/terraform/aws/bastion-aws/ssh.cfg
@@ -1,0 +1,12 @@
+Host *
+  PubkeyAuthentication yes
+
+Host bastion
+  Hostname 54.70.95.123
+  User ec2-user
+  IdentityFile ~/.ssh/aws_rsa
+
+Host 10.2.1.*
+  User ec2-user
+  IdentityFile ~/.ssh/aws_rsa
+  ProxyCommand ssh bastion -W %h:%p

--- a/terraform/aws/bastion-aws/vars.tf
+++ b/terraform/aws/bastion-aws/vars.tf
@@ -1,0 +1,11 @@
+variable "keypair" {
+    type                    = "string"
+    description             = "AWS SSH keypair to use to connect to instances"
+    default                 = "aws_rsa"
+}
+
+variable "flavor" {
+    type                    = "string"
+    description             = "AWS type to use when creating instances"
+    default                 = "t2.micro"
+}

--- a/terraform/aws/bastion-aws/vars.tf
+++ b/terraform/aws/bastion-aws/vars.tf
@@ -1,11 +1,9 @@
 variable "keypair" {
     type                    = "string"
     description             = "AWS SSH keypair to use to connect to instances"
-    default                 = "aws_rsa"
 }
 
 variable "flavor" {
     type                    = "string"
     description             = "AWS type to use when creating instances"
-    default                 = "t2.micro"
 }


### PR DESCRIPTION
The goal would be to provide sample Terraform configurations so that users can see how to build out an entirely new AWS environment (new VPC, new subnets, new security groups, etc.) with an SSH bastion host for secure SSH access to private instances.