### PR TITLE
Clean up simple EC2 environment

### DIFF
--- a/terraform/aws/simple-ec2/output.tf
+++ b/terraform/aws/simple-ec2/output.tf
@@ -1,0 +1,3 @@
+output "instance_ip_address" {
+    value = "${aws_instance.test-01.public_ip}"
+}

--- a/terraform/aws/simple-ec2/provider.tf
+++ b/terraform/aws/simple-ec2/provider.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-    region                  = "us-west-2"
+    region                  = "${var.user_region}"
 }

--- a/terraform/aws/simple-ec2/variables.tf
+++ b/terraform/aws/simple-ec2/variables.tf
@@ -1,17 +1,19 @@
+variable "user_region" {
+    type                    = "string"
+    description             = "AWS region in which to create all resources"
+}
+
 variable "keypair" {
     type                    = "string"
     description             = "AWS SSH keypair to use to connect to instances"
-    default                 = "aws_rsa"
 }
 
 variable "flavor" {
     type                    = "string"
     description             = "AWS type to use when creating instances"
-    default                 = "t2.micro"
 }
 
 variable "sec-group" {
     type                    = "string"
     description             = "AWS security group to apply to instances"
-    default                 = "sg-7099b514"
 }


### PR DESCRIPTION
The "simple-ec2" environment needs some cleanup to make it easier for other people to use. Variables need to be moved to a `*.tfvars` file (excluded from source control) and output needs to be added.