### PR TITLE
Clean up environment

### DIFF
--- a/terraform/aws/new-vpc/output.tf
+++ b/terraform/aws/new-vpc/output.tf
@@ -1,0 +1,3 @@
+output "instance_public_ip" {
+    value = "${aws_instance.coreos01.public_ip}"
+}

--- a/terraform/aws/new-vpc/provider.tf
+++ b/terraform/aws/new-vpc/provider.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-    region                  = "us-west-2"
+    region                  = "${var.user_region}"
 }

--- a/terraform/aws/new-vpc/variables.tf
+++ b/terraform/aws/new-vpc/variables.tf
@@ -1,11 +1,14 @@
+variable "user_region" {
+    type                    = "string"
+    description             = "AWS region in which all resources will be created"
+}
+
 variable "keypair" {
     type                    = "string"
     description             = "AWS SSH keypair to use to connect to instances"
-    default                 = "aws_rsa"
 }
 
 variable "flavor" {
     type                    = "string"
     description             = "AWS type to use when creating instances"
-    default                 = "t2.micro"
 }


### PR DESCRIPTION
Clean up Terraform+AWS `new-vpc` environment to adhere to standards described in issue #80.

Signed-off-by: Scott Lowe <scott.lowe@scottlowe.org>