### PR TITLE
Add initial contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribution Guidelines
+
+Contributions are encouraged and welcomed. Here are some guidelines for participating in and contributing to this community.
+
+## How to behave and interact
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, political beliefs, or similar personal characteristic.
+
+We require that anyone wishing to participate in this community adhere to the following guidelines:
+
+* Please avoid using any usernames or nicknames that might detract from a friendly, safe and welcoming environment for all.
+
+* Please be kind and courteous. There's no need to be mean or rude. Respect other people's opinions and viewpoints, even if they differ from your own.
+
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+
+* Do not insult, demean, or harass anyone. That is not welcome behavior. If you have any lack of clarity about what might be included in the term "harassment," contact me. Private harassment is also unacceptable. If you feel you have been or are being harassed or made uncomfortable by a community member, please contact a maintainer immediately.
+
+* Spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+
+## How to collaborate
+
+GitHub issues are the primary way to collaborate regarding proposed changes to this project.
+
+Some contributors may also be available on Slack and/or IRC, but there is no dedicated channel for discussing this project.
+
+## How to contribute
+
+Pull requests (PR) are the primary means whereby you can contribute. Before opening a PR, please open a GitHub issue first to discuss the proposed changes and get feedback from the community. This also helps reduce duplication, since someone else may be working on a similar contribution.
+
+Other guidelines include:
+
+* You _do not_ need to squash commits before submitting your PR.
+
+* You _do_ need to sign all commits (use `-s` with `git commit`).
+
+* You _do_ need to include documentation, in the form of a comprehensive `README.md`, for all new learning environments.


### PR DESCRIPTION
Add initial contribution guidelines in the form of CONTRIBUTING.md.

Closes #84.

Signed-off-by: Scott Lowe <scott.lowe@scottlowe.org>