### PR TITLE
Add learning environment demonstrating cloud-init to customize Docker

### DIFF
--- a/centos-atomic/docker-cloudinit/README.md
+++ b/centos-atomic/docker-cloudinit/README.md
@@ -1,0 +1,38 @@
+# Instructions
+
+1. Capture the VPC ID of your default VPC using this command:
+
+        VPC_ID=$(aws --output text ec2 describe-vpcs \
+        --filters Name=isDefault,Values="true" \
+        --query 'Vpcs[0].VpcId')
+
+2. Capture the subnet ID of one of the subnets (the first, by default) in the default VPC using this command (step 1 must be completed first):
+
+        SN_ID=$(aws --output text ec2 describe-subnets \
+        --filters Name=vpc-id,Values="$VPC_ID" \
+        --query 'sort_by(Images,&AvailabilityZone)[0].SubnetId')
+
+3. Capture the security group ID of a security group in the default VPC with the name "default" (it is assumed that this security group exists and allows SSH access to the instance; if this is not the case, you must fix this outside of this process):
+
+        SG_ID=$(aws --output text ec2 describe-security-groups \
+        --filters Name=group-name,Values="default" \
+        Name=vpc-id,Values="$VPC_ID" \
+        --query 'SecurityGroups[0].GroupId')
+
+4. Finally, capture the image ID of the latest version of the CentOS 7 Atomic Host AMI using this command:
+
+        IMAGE_ID=$(aws --output text ec2 describe-images \
+        --owners 410186602215 --filter Name=name,Values="*CentOS Atomic*" \
+        --query 'sort_by(Images,&CreationDate)[-1].ImageId')
+
+5. Make sure you have an SSH key available to use with the instance and make note of the name of the SSH key.
+
+6. Launch an AWS instance using this command:
+
+        aws ec2 run-instances --image-id $IMAGE_ID --instance-type t2.micro \
+        --key-name keyname --user-data file://cloud-config.yml \
+        --subnet-id $SN_ID --security-group-ids $SG_ID
+
+7. Connect to the instance using SSH.
+
+8. Verify that the Docker daemon is listening over a network socket (not the default configuration) by running `ss -lnt` and/or running `docker` commands against the network socket (via `-H tcp://127.0.0.1:2375`).

--- a/centos-atomic/docker-cloudinit/cloud-config.yml
+++ b/centos-atomic/docker-cloudinit/cloud-config.yml
@@ -55,6 +55,9 @@ write_files:
     permissions: '0644'
 runcmd:
   - systemctl daemon-reload
+  - systemctl enable docker.service
+  - systemctl enable docker.socket
+  - systemctl enable docker-tcp.socket
   - systemctl stop docker.service
   - systemctl start docker.socket
   - systemctl start docker-tcp.socket

--- a/centos-atomic/docker-cloudinit/cloud-config.yml
+++ b/centos-atomic/docker-cloudinit/cloud-config.yml
@@ -1,0 +1,61 @@
+#cloud-config
+# vim: syntax=yaml
+
+groups:
+  - docker: [root,centos]
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChbmG4wPh/f5CtB5hmepkUHwLKCBXuVX7CcxryMDfXx4W/2ffLO9J/Ek1w58ED3o5/KExduXjwtpMAvOoBffJsaSmm+Tc1NwzyR7GZ75MJYE1/5z5gkBUkZpjmM6qXCpiD6m3jIbaSxxfNEBL64i6H+UL6Ak1LKuYCLutTex+f4Q0NgJvRQyyG2Ms04egWjp91Kbd/cTA3/zfXGI2T3ZvGScvLcUE/neUgBloykuYi0k+VcFK0RAPjqfITaZXs6vtcPLXSX6CR4eHwgM8WpfO3sCEFkMwIhystAFapzSRdfHgtln0XZz84iydcvZVW1o3W8FTiOoNxDoC9ph6XmlU3 scott.lowe@scottlowe.org
+write_files:
+  - content: |
+      [Unit]
+      Description=UNIX Socket for the Docker API
+      PartOf=docker.service
+
+      [Socket]
+      ListenStream=/var/run/docker.sock
+      SocketMode=0660
+      SocketUser=root
+      SocketGroup=docker
+
+      [Install]
+      WantedBy=sockets.target
+    path: /etc/systemd/system/docker.socket
+    owner: root:root
+    permissions: '0644'
+  - content: |
+      [Unit]
+      Description=TCP Socket for the Docker API
+
+      [Socket]
+      ListenStream=2375
+      BindIPv6Only=both
+      Service=docker.service
+
+      [Install]
+      WantedBy=sockets.target
+    path: /etc/systemd/system/docker-tcp.socket
+    owner: root:root
+    permissions: '0644'
+  - content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/dockerd-current -H fd:// \
+                --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
+                --default-runtime=docker-runc \
+                --exec-opt native.cgroupdriver=systemd \
+                --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
+                $OPTIONS \
+                $DOCKER_STORAGE_OPTIONS \
+                $DOCKER_NETWORK_OPTIONS \
+                $ADD_REGISTRY \
+                $BLOCK_REGISTRY \
+                $INSECURE_REGISTRY
+    path: /etc/systemd/system/docker.service.d/docker-socket.conf
+    owner: root:root
+    permissions: '0644'
+runcmd:
+  - systemctl daemon-reload
+  - systemctl stop docker.service
+  - systemctl start docker.socket
+  - systemctl start docker-tcp.socket
+  - systemctl start docker.service

--- a/centos-atomic/docker-cloudinit/cloud-config.yml
+++ b/centos-atomic/docker-cloudinit/cloud-config.yml
@@ -2,20 +2,18 @@
 # vim: syntax=yaml
 
 groups:
-  - docker: [root,centos]
-ssh_authorized_keys:
-  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChbmG4wPh/f5CtB5hmepkUHwLKCBXuVX7CcxryMDfXx4W/2ffLO9J/Ek1w58ED3o5/KExduXjwtpMAvOoBffJsaSmm+Tc1NwzyR7GZ75MJYE1/5z5gkBUkZpjmM6qXCpiD6m3jIbaSxxfNEBL64i6H+UL6Ak1LKuYCLutTex+f4Q0NgJvRQyyG2Ms04egWjp91Kbd/cTA3/zfXGI2T3ZvGScvLcUE/neUgBloykuYi0k+VcFK0RAPjqfITaZXs6vtcPLXSX6CR4eHwgM8WpfO3sCEFkMwIhystAFapzSRdfHgtln0XZz84iydcvZVW1o3W8FTiOoNxDoC9ph6XmlU3 scott.lowe@scottlowe.org
+  - docker: [centos,root]
 write_files:
   - content: |
       [Unit]
       Description=UNIX Socket for the Docker API
-      PartOf=docker.service
 
       [Socket]
       ListenStream=/var/run/docker.sock
       SocketMode=0660
       SocketUser=root
       SocketGroup=docker
+      Service=docker.service
 
       [Install]
       WantedBy=sockets.target
@@ -54,11 +52,13 @@ write_files:
     owner: root:root
     permissions: '0644'
 runcmd:
-  - systemctl daemon-reload
-  - systemctl enable docker.service
-  - systemctl enable docker.socket
-  - systemctl enable docker-tcp.socket
-  - systemctl stop docker.service
-  - systemctl start docker.socket
-  - systemctl start docker-tcp.socket
-  - systemctl start docker.service
+  - [ systemctl, start, docker-storage-setup ]
+  - [ systemctl, mask, docker-storage-setup ]
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, docker.service ]
+  - [ systemctl, enable, docker.socket ]
+  - [ systemctl, enable, docker-tcp.socket ]
+  - [ systemctl, stop, docker.service ]
+  - [ systemctl, start, docker.socket ]
+  - [ systemctl, start, docker-tcp.socket ]
+  - [ systemctl, start, docker.service ]

--- a/centos-atomic/docker-cloudinit/launch.sh
+++ b/centos-atomic/docker-cloudinit/launch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# This script assumes AWSCLI is installed and configured correctly
+
+# Set some variables to be used later
+TYPE="t2.micro"
+KEYNAME="aws_rsa"
+
+# First, capture the ID of the user's default VPC
+VPC_ID=$(aws --output text ec2 describe-vpcs \
+         --filters Name=isDefault,Values=true \
+         --query 'Vpcs[0].VpcId')
+
+# Use the captured VPC_ID to get the subnet ID of the first subnet
+# in the first (sorted alphabetically) availability zone in the user's
+# configured region
+SN_ID=$(aws --output text ec2 describe-subnets \
+        --filters Name=vpc-id,Values="$VPC_ID" \
+        --query 'sort_by(Subnets,&AvailabilityZone)[0].SubnetId')
+
+# Capture the ID of the security group named "default" in the
+# user's default VPC.
+SG_ID=$(aws --output text ec2 describe-security-groups \
+        --filters Name=group-name,Values="default" \
+        Name=vpc-id,Values="$VPC_ID" \
+        --query 'SecurityGroups[0].GroupId')
+
+# Capture the AMI ID for the latest version of CentOS 7 Atomic Host
+IMG_ID=$(aws --output text ec2 describe-images \
+         --owners 410186602215 \
+         --filters Name=name,Values="*CentOS Atomic*" \
+         --query 'sort_by(Images,&CreationDate)[-1].ImageId')
+
+# Launch an instance using the captured information from above (no cloud-init)
+#aws ec2 run-instances --image-id $IMG_ID --instance-type $TYPE \
+#--key-name $KEYNAME --subnet-id $SN_ID --security-group-ids $SG_ID
+
+# Launch an instance using the captured information from above (with cloud-init)
+aws ec2 run-instances --image-id $IMG_ID --instance-type $TYPE \
+--key-name $KEYNAME --user-data file://cloud-config.yml \
+--subnet-id $SN_ID --security-group-ids $SG_ID

--- a/centos-atomic/docker-cloudinit/ssh.cfg
+++ b/centos-atomic/docker-cloudinit/ssh.cfg
@@ -1,0 +1,2 @@
+Host *
+  PubkeyAuthentication yes

--- a/centos-atomic/docker-cloudinit/ssh.cfg
+++ b/centos-atomic/docker-cloudinit/ssh.cfg
@@ -1,2 +1,4 @@
+UserKnownHostsFile ./known_hosts
+
 Host *
   PubkeyAuthentication yes

--- a/terraform/aws/bastion-aws/ssh.cfg.example
+++ b/terraform/aws/bastion-aws/ssh.cfg.example
@@ -9,4 +9,4 @@ Host bastion
 Host 10.2.2.*
   User centos
   IdentityFile </path/to/SSH/keypair>
-  ProxyCommand ssh bastion -W %h:%p
+  ProxyCommand ssh -F </path/to/ssh.cfg> bastion -W %h:%p


### PR DESCRIPTION
Adds files to demonstrate the use of `cloud-init` on AWS to customize the Docker daemon on CentOS Atomic Host. Assumes the presence of the AWS CLI.

Closes #86.