### PR TITLE
Add learning environment for Traefik on local Docker Swarm mode cluster

### DIFF
--- a/traefik/vagrant-ansible/README.md
+++ b/traefik/vagrant-ansible/README.md
@@ -1,0 +1,41 @@
+# Docker Swarm Mode with CoreOS
+
+These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) quickly and relatively easily test Docker "Swarm Mode" using CentOS Atomic Host. This environment was tested using Vagrant 1.9.1 with VirtualBox 5.1.14, but should work with Vagrant's VMware provider as well.
+
+## Contents
+
+* **machines.yml**: This YAML file contains a list of VM definitions. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. You will need to edit this file to provide the correct Vagrant box names. Other edits should not be necessary.
+
+* **README.md**: This file you're currently reading.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
+
+## Instructions
+
+These instructions assume you've already installed your virtualization provider (VMware Fusion/Workstation or VirtualBox), Vagrant, and any necessary plugins (such as the Vagrant VMware plugin). Please refer to the documentation for those products for more information on installation or configuration.
+
+1. Use `vagrant box add` to install the CentOS Atomic Host box. For VirtualBox, you can use `vagrant box add centos/atomic-host`. Users of a VMware virtualization provider will likely need to create their own Vagrant box.
+
+2. Place the files from the `docker/atomic-swarm-mode` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the the `docker/atomic-swarm-mode` folder.
+
+3. If the name of your CentOS Atomic Host Vagrant box is _not_ "centos/atomic-host", edit `machines.yml` to supply the correct box name. This file has separate lines for the VirtualBox and VMware providers; be sure to edit the correct line for your provider.
+
+4. Run `vagrant up` to instantiate 4 VMs---one manager and three workers. All the VMs will be running CentOS Atomic Host.
+
+5. Once Vagrant is finished, use `vagrant ssh manager` to log into the manager VM.
+
+6. Edit the `/etc/docker/daemon.json` file to specify "live-restore" is false (change from true). Restart the Docker daemon with `sudo systemctl restart docker` in order for that change to take effect. (This setting is incompatible with Docker's Swarm mode.)
+
+7. While logged into the manager VM, run `docker swarm init --advertise-addr 192.168.100.100` to create a new swarm. If you have edited the IP addresses supplied in `machines.yml`, then you'll need to adjust the command accordingly to use the IP address supplied for the manager VM.
+
+	The output of that command will provide a command-line to use to join worker nodes to the swarm. Copy and paste this output; you'll need it shortly.
+
+8. Log out of the VM and use `vagrant ssh worker-01` to log in to the first worker VM. Repeat step #6 to make the Docker daemon ready to join the Swarm.
+
+9. Paste the output of step #7 to have the worker node join the swarm.
+
+10. Repeat steps #8 and #9 for the remaining worker nodes.
+
+11. Use `vagrant ssh manager` to log back into the manager VM. Run `docker node ls` to show the Docker Engine instances participating in the swarm.
+
+Enjoy!

--- a/traefik/vagrant-ansible/README.md
+++ b/traefik/vagrant-ansible/README.md
@@ -1,41 +1,81 @@
-# Docker Swarm Mode with CoreOS
+# Using Traefik on a Local Docker Swarm Mode Cluster
 
-These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) quickly and relatively easily test Docker "Swarm Mode" using CentOS Atomic Host. This environment was tested using Vagrant 1.9.1 with VirtualBox 5.1.14, but should work with Vagrant's VMware provider as well.
+These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) and Ansible ([http://www.ansible.com](http://www.ansible.com)) to quickly and relatively easily spin up a Docker Swarm mode cluster for the purpose of using/learning/playing with Traefik ([http://traefik.io](http://traefik.io)), a dynamic reverse proxy used in microservices-based architectures.
 
 ## Contents
 
-* **machines.yml**: This YAML file contains a list of VM definitions. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. You will need to edit this file to provide the correct Vagrant box names. Other edits should not be necessary.
+* **ansible.cfg**: This Ansible configuration file supplies configuration to Ansible to streamline integration with the Vagrant Ansible provisioner.
+
+* **create-swarm.yml**: This Ansible playbook configures a group of VMs (created by Vagrant) to be a Docker Swarm cluster.
+
+* **destroy-swarm.yml**: This Ansible playbook forcefully destroys the Docker Swarm mode cluster.
+
+* **machines.yml**: This YAML file contains a list of VM definitions. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs. Generally, the only change needed to this file is to specify the correct Vagrant box you will be used (see "Instructions" below). If necessary, you may need to edit the IP addresses supplied in this file to avoid IP addressing conflicts with other networks.
+
+* **provision.yml**: This is the Ansible playbook that will perform a very light edit to the VMs, primarily for the purpose of creating the appropriate Ansible inventory file by the . No edits to this file should be necessary.
 
 * **README.md**: This file you're currently reading.
 
 * **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
 
-## Instructions
+## Instructions - Docker Swarm Mode Cluster
 
-These instructions assume you've already installed your virtualization provider (VMware Fusion/Workstation or VirtualBox), Vagrant, and any necessary plugins (such as the Vagrant VMware plugin). Please refer to the documentation for those products for more information on installation or configuration.
+These instructions assume you've already installed your virtualization provider (typically VirtualBox, VMware Fusion, or VMware Workstation), Vagrant, any necessary Vagrant plugins, and Ansible. Please refer to the documentation for those products for more information on installation or configuration.
 
-1. Use `vagrant box add` to install the CentOS Atomic Host box. For VirtualBox, you can use `vagrant box add centos/atomic-host`. Users of a VMware virtualization provider will likely need to create their own Vagrant box.
+1. Use `vagrant box add` to install an Ubuntu 14.04 x64 box for the vmware_fusion provider. The "bento/ubuntu-14.04" box is a good option here.
 
-2. Place the files from the `docker/atomic-swarm-mode` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the the `docker/atomic-swarm-mode` folder.
+2. Place the files from the `docker/ubuntu-swarm-mode` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the the `docker/ubuntu-swarm-mode` folder.
 
-3. If the name of your CentOS Atomic Host Vagrant box is _not_ "centos/atomic-host", edit `machines.yml` to supply the correct box name. This file has separate lines for the VirtualBox and VMware providers; be sure to edit the correct line for your provider.
+3. Edit the `machines.yml` file to specify the box you will use (as specified in step 1). If necessary to avoid IP address conflicts with existing networks, you may also need to edit the IP addresses specified in this file. Generally, no other changes are needed, although (if you are comfortable with the settings) you can adjust the number of virtual CPUs and/or the amount of RAM assigned to each Vagrant VM in this file as well. Note that this environment _assumes_ the presence of an `eth1` in each Vagrant VM; therefore, do not remove the "ip_addr" value from `machines.yml`.
 
-4. Run `vagrant up` to instantiate 4 VMs---one manager and three workers. All the VMs will be running CentOS Atomic Host.
+4. Once you have edited `machines.yml`, use `vagrant up` to bring up the systems that will serve as your Swarm mode cluster. As part of the process of running `vagrant up`, you'll see Ansible perform a quick task on each VM.
 
-5. Once Vagrant is finished, use `vagrant ssh manager` to log into the manager VM.
+5. Once Vagrant has finished bringing up the VMs, run `ansible-playbook create-swarm.yml`. This will configure the VMs and get a Docker Swarm mode cluster up and running.
 
-6. Edit the `/etc/docker/daemon.json` file to specify "live-restore" is false (change from true). Restart the Docker daemon with `sudo systemctl restart docker` in order for that change to take effect. (This setting is incompatible with Docker's Swarm mode.)
+At this point, you have a functional Docker Swarm mode cluster. You should have IP connectivity to the hosts, and you can log into the manager and run `docker node ls` to see the nodes in the Swarm mode cluster.
 
-7. While logged into the manager VM, run `docker swarm init --advertise-addr 192.168.100.100` to create a new swarm. If you have edited the IP addresses supplied in `machines.yml`, then you'll need to adjust the command accordingly to use the IP address supplied for the manager VM.
+## Instructions - Traefik and Containerized Web Services
 
-	The output of that command will provide a command-line to use to join worker nodes to the swarm. Copy and paste this output; you'll need it shortly.
+Once you've used Vagrant+Ansible to spin up a local Docker Swarm mode cluster, you're ready to start deploying Traefik to dynamically proxy web services running in containers on the cluster.
 
-8. Log out of the VM and use `vagrant ssh worker-01` to log in to the first worker VM. Repeat step #6 to make the Docker daemon ready to join the Swarm.
+1. Create an overlay network (the name isn't important, but make note of what name you use as you'll need it later):
 
-9. Paste the output of step #7 to have the worker node join the swarm.
+        docker network create --driver=overlay demo-net
 
-10. Repeat steps #8 and #9 for the remaining worker nodes.
+2. Using `docker service create`, create a service (constrained to the manager node) to run the Traefik reverse proxy:
 
-11. Use `vagrant ssh manager` to log back into the manager VM. Run `docker node ls` to show the Docker Engine instances participating in the swarm.
+        docker service create --name traefik \
+        --constraint 'node.role==manager' \
+        --publish 80:80 --publish 8080:8080 \
+        --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+        --network demo-net
+        traefik --web --docker --docker.watch \
+        --docker.swarmmode --docker.domain=docker.local
+
+    If you'd like additional logging, add `--logLevel=DEBUG` to the above command. If you used a name other than "demo-net" in step 1, supply it here after the `--network` parameter.
+
+3. Deploy a web service to be used behind Traefik:
+
+        docker service create --name www \
+        --label 'traefik.port=5000' \
+        --network demo-net slowe/flask-demo-app:1.0
+
+    If you used a network name other than "demo-net", supply it here after the `--network` parameter. Feel free to use a different container image; this simple container image is designed to be used in situations like this.
+
+4. Run this command against the IP address of the manager VM and note the output:
+
+        curl -H "Host:www.docker.local" http://<manager_ip_address>
+
+    If you used a name other than "www" in step 3, replace that name in the "Host" portion of the above command.
+
+5. Run `docker service scale www=3` to scale up the "www" service (replace "www" with whatever name you used in step 3). Repeat step 4 and note that Traefik will load balance across the different containers hosting the service.
+
+6. Repeat steps 3 through 5, replacing "www" with something different in step 3 and using that same (new) name in steps 4 and 5 (so, if you use "blog" in step 3, use "blog" in steps 4 and 5). You'll note that Traefik will automatically route inbound traffic to the right set of containers based on the Host header being supplied.
+
+Refer to the Traefik documentation for additional labels that can be added to the `docker service create` command to further customize/affect the behavior of Traefik.
 
 Enjoy!
+
+## License
+
+This content is licensed under the MIT License.

--- a/traefik/vagrant-ansible/Vagrantfile
+++ b/traefik/vagrant-ansible/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify minimum Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, RAM, IP addresses)
+# Edit machines.yml to change VM configuration details
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+
+    # Configure the VMs per details in machines.yml
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+
+      # Specify the hostname of the VM
+      srv.vm.hostname = machine['name']
+
+      # Specify the Vagrant box to use (use VMware box by default)
+      srv.vm.box = machine['box']['vmw']
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Iterate through networks as per settings in machines.yml
+      machine['nics'].each do |net|
+        if net['ip_addr'] == 'dhcp'
+          srv.vm.network net['type'], type: net['ip_addr']
+        else
+          srv.vm.network net['type'], ip: net['ip_addr']
+        end # if net['ip_addr']
+      end # machine['nics'].each
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider 'vmware_fusion'
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['box']['vb']
+      end # srv.vm.provider 'virtualbox'
+    end # config.vm.define
+  end # machines.each
+
+  # Gather facts in order to create Ansible inventory file
+  config.vm.provision 'ansible' do |ansible|
+    ansible.playbook = 'provision.yml'
+  end # config.vm.provision
+end # Vagrant.configure

--- a/traefik/vagrant-ansible/ansible.cfg
+++ b/traefik/vagrant-ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
+private_key_file = ~/.vagrant.d/insecure_private_key
+remote_user = vagrant
+host_key_checking = False

--- a/traefik/vagrant-ansible/create-swarm.yml
+++ b/traefik/vagrant-ansible/create-swarm.yml
@@ -4,19 +4,83 @@
   remote_user: "vagrant"
 
   tasks:
+  - name: "Install Pip"
+    apt:
+      name: "python-pip"
+      state: "present"
+      update_cache: "yes"
+    tags:
+      - manager
+      - worker
+
+  - name: "Install some Python modules"
+    pip:
+      name: "{{ item }}"
+      state: "present"
+    with_items:
+      - "urllib3"
+      - "pyopenssl"
+      - "ndg-httpsclient"
+      - "pyasn1"
+    tags:
+      - manager
+      - worker
+
+  - name: "Install Docker APT Key"
+    apt_key:
+      url: "https://download.docker.com/linux/ubuntu/gpg"
+      state: "present"
+    tags:
+      - manager
+      - worker
+
+  - name: "Add Docker repository"
+    apt_repository:
+      repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu trusty stable"
+      state: "present"
+      update_cache: "yes"
+    tags:
+      - manager
+      - worker
+
+  - name: "Install Docker CE"
+    package:
+      name: "docker-ce"
+      state: "present"
+    tags:
+      - manager
+      - worker
+
+  - name: "Add user to Docker group"
+    user:
+      name: "{{ ansible_ssh_user }}"
+      group: "docker"
+      append: "yes"
+    tags:
+      - manager
+      - worker
+
   - name: "Initialize Docker Swarm from manager"
-    command: "docker swarm init --advertise-addr {{ ansible_default_ipv4.address }}"
-    when: ansible_hostname == "manager"
+    command: "docker swarm init --advertise-addr {{ ansible_eth1.ipv4.address }}"
+    when: ansible_hostname == 'manager'
+    tags:
+      - manager
 
   - name: "Register Swarm join token"
     command: "docker swarm join-token -q worker"
     register: swarm_token
-    when: ansible_hostname == "manager"
+    when: ansible_hostname == 'manager'
+    tags:
+      - manager
 
   - name: "Establish Swarm join token as a host fact"
     set_fact: swarmtoken="{{ swarm_token.stdout }}"
-    when: ansible_hostname == "manager"
+    when: ansible_hostname == 'manager'
+    tags:
+      - manager
 
   - name: "Join worker nodes to Swarm cluster"
-    command: "docker swarm join --advertise-addr {{ ansible_default_ipv4.address }} --token {{ swarmtoken }} {{ hostvars[groups['tag_role_manager'][0]].ansible_default_ipv4.address }}:2377"
-    when: ansible_hostname != "manager"
+    command: "docker swarm join --advertise-addr {{ ansible_eth1.ipv4.address }} --token {{ hostvars['manager'].swarmtoken }} {{ hostvars['manager']['ansible_eth1']['ipv4']['address'] }}:2377"
+    when: ansible_hostname != 'manager'
+    tags:
+      - worker

--- a/traefik/vagrant-ansible/create-swarm.yml
+++ b/traefik/vagrant-ansible/create-swarm.yml
@@ -1,0 +1,22 @@
+---
+- hosts: "all"
+  become: "yes"
+  remote_user: "vagrant"
+
+  tasks:
+  - name: "Initialize Docker Swarm from manager"
+    command: "docker swarm init --advertise-addr {{ ansible_default_ipv4.address }}"
+    when: ansible_hostname == "manager"
+
+  - name: "Register Swarm join token"
+    command: "docker swarm join-token -q worker"
+    register: swarm_token
+    when: ansible_hostname == "manager"
+
+  - name: "Establish Swarm join token as a host fact"
+    set_fact: swarmtoken="{{ swarm_token.stdout }}"
+    when: ansible_hostname == "manager"
+
+  - name: "Join worker nodes to Swarm cluster"
+    command: "docker swarm join --advertise-addr {{ ansible_default_ipv4.address }} --token {{ swarmtoken }} {{ hostvars[groups['tag_role_manager'][0]].ansible_default_ipv4.address }}:2377"
+    when: ansible_hostname != "manager"

--- a/traefik/vagrant-ansible/destroy-swarm.yml
+++ b/traefik/vagrant-ansible/destroy-swarm.yml
@@ -1,0 +1,8 @@
+---
+- hosts: "us-west-2"
+  become: "yes"
+  remote_user: "ubuntu"
+
+  tasks:
+  - name: "Leave Swarm cluster"
+    command: "docker swarm leave --force"

--- a/traefik/vagrant-ansible/destroy-swarm.yml
+++ b/traefik/vagrant-ansible/destroy-swarm.yml
@@ -1,7 +1,7 @@
 ---
-- hosts: "us-west-2"
+- hosts: "all"
   become: "yes"
-  remote_user: "ubuntu"
+  remote_user: "vagrant"
 
   tasks:
   - name: "Leave Swarm cluster"

--- a/traefik/vagrant-ansible/machines.yml
+++ b/traefik/vagrant-ansible/machines.yml
@@ -1,7 +1,7 @@
 ---
 - box:
-    vmw: "centos/atomic-host"
-    vb: "fedora/26-atomic-host"
+    vmw: "bento/ubuntu-14.04"
+    vb: "bento/ubuntu-14.04"
   name: "manager"
   nics:
     - type: "private_network"
@@ -9,8 +9,8 @@
   ram: "512"
   vcpu: "1"
 - box:
-    vmw: "centos/atomic-host"
-    vb: "fedora/26-atomic-host"
+    vmw: "bento/ubuntu-14.04"
+    vb: "bento/ubuntu-14.04"
   name: "worker-01"
   nics:
     - type: "private_network"
@@ -18,8 +18,8 @@
   ram: "512"
   vcpu: "1"
 - box:
-    vmw: "centos/atomic-host"
-    vb: "fedora/26-atomic-host"
+    vmw: "bento/ubuntu-14.04"
+    vb: "bento/ubuntu-14.04"
   name: "worker-02"
   nics:
     - type: "private_network"
@@ -27,8 +27,8 @@
   ram: "512"
   vcpu: "1"
 - box:
-    vmw: "centos/atomic-host"
-    vb: "fedora/26-atomic-host"
+    vmw: "bento/ubuntu-14.04"
+    vb: "bento/ubuntu-14.04"
   name: "worker-03"
   nics:
     - type: "private_network"
@@ -36,8 +36,8 @@
   ram: "512"
   vcpu: "1"
 - box:
-    vmw: "centos/atomic-host"
-    vb: "fedora/26-atomic-host"
+    vmw: "bento/ubuntu-14.04"
+    vb: "bento/ubuntu-14.04"
   name: "worker-04"
   nics:
     - type: "private_network"

--- a/traefik/vagrant-ansible/machines.yml
+++ b/traefik/vagrant-ansible/machines.yml
@@ -1,0 +1,46 @@
+---
+- box:
+    vmw: "centos/atomic-host"
+    vb: "fedora/26-atomic-host"
+  name: "manager"
+  nics:
+    - type: "private_network"
+      ip_addr: "192.168.100.100"
+  ram: "512"
+  vcpu: "1"
+- box:
+    vmw: "centos/atomic-host"
+    vb: "fedora/26-atomic-host"
+  name: "worker-01"
+  nics:
+    - type: "private_network"
+      ip_addr: "192.168.100.101"
+  ram: "512"
+  vcpu: "1"
+- box:
+    vmw: "centos/atomic-host"
+    vb: "fedora/26-atomic-host"
+  name: "worker-02"
+  nics:
+    - type: "private_network"
+      ip_addr: "192.168.100.102"
+  ram: "512"
+  vcpu: "1"
+- box:
+    vmw: "centos/atomic-host"
+    vb: "fedora/26-atomic-host"
+  name: "worker-03"
+  nics:
+    - type: "private_network"
+      ip_addr: "192.168.100.103"
+  ram: "512"
+  vcpu: "1"
+- box:
+    vmw: "centos/atomic-host"
+    vb: "fedora/26-atomic-host"
+  name: "worker-04"
+  nics:
+    - type: "private_network"
+      ip_addr: "192.168.100.104"
+  ram: "512"
+  vcpu: "1"

--- a/traefik/vagrant-ansible/provision.yml
+++ b/traefik/vagrant-ansible/provision.yml
@@ -1,0 +1,8 @@
+---
+- hosts: "all"
+  remote_user: "vagrant"
+  become: "yes"
+
+  tasks:
+    - name: Verify Ansible connectivity
+      ping:

--- a/traefik/vagrant-ansible/provision.yml
+++ b/traefik/vagrant-ansible/provision.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: "all"
-  remote_user: "vagrant"
   become: "yes"
+  remote_user: "vagrant"
 
   tasks:
     - name: Verify Ansible connectivity


### PR DESCRIPTION
This learning environment (based on the `docker/ubuntu-swarm-mode` environment) will allow users to spin up a local Docker Swarm mode cluster and then deploy Traefik and other web services onto it. This will facilitate learning how Traefik (and other dynamic reverse proxies) work in microservices-based environments.