### PR TITLE
Add an environment demonstrating how to dynamically accommodate availability zones

### DIFF
--- a/terraform/aws/vpc-all-azs/README.md
+++ b/terraform/aws/vpc-all-azs/README.md
@@ -1,0 +1,35 @@
+# Creating Subnets and Instances on All Availability Zones
+
+These files provide an example of how to use Terraform data sources and functions to create subnets on all availability zones (AZs) within a user-specified region, and then launch instances spread across the subnets.
+
+## Contents
+
+* **compute.tf**: This Terraform configuration file launches the instances across the subnets within the VPC.
+
+* **data.tf**: This Terraform configuration provides the data sources used by other configuration files (the AZs within a region and the AMI to use to launch an instance).
+
+* **networking.tf**: This Terraform configuration creates a new VPC and then creates a subnet in each AZ within the region. It also creates an Internet gateway and programs a route in the main route table for the VPC.
+
+* **provider.tf**: This Terraform configuration files configures the AWS provider.
+
+* **README.md**: The file you're currently reading.
+
+* **variables.tf**: This Terraform configuration file specifies variables that Terraform will need in order to create the desired AWS infrastructure.
+
+## Instructions
+
+These instructions assume that you have an AWS account, that Terraform is installed and working correctly, and that you've appropriately supplied the necessary AWS credentials to Terraform. If the AWS CLI works properly, then Terraform can use those credentials to connect to AWS.
+
+1. Place the files from the `terraform/aws/vpc-all-azs` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the `terraform/aws/vpc-all-azs` folder.
+
+2. Create a file named `terraform.tfvars` and populate it with the name of the AWS region to use, a CIDR block to use (a /16 block is recommended), the instance type to use, the SSH keypair to inject into the instances, and the number of instances you'd like to launch. Refer to [this URL](https://www.terraform.io/intro/getting-started/variables.html) for specific details on the syntax of this file. You can refer to the contents of `variables.tf` for the names of the variables that need to be defined.
+
+3. Run `terraform plan` to have Terraform examine the current infrastructure and determine what changes are necessary to realize the desired configuration.
+
+4. Run `terraform apply` to have Terraform make the changes necessary to realize the desired configuration. Once Terraform has finished executing, you can use SSH (with the specified key pair) to log into one or more of the instances.
+
+Enjoy!
+
+## License
+
+This content is licensed under the MIT License.

--- a/terraform/aws/vpc-all-azs/compute.tf
+++ b/terraform/aws/vpc-all-azs/compute.tf
@@ -1,0 +1,15 @@
+# Launch instances across subnets/AZs
+resource "aws_instance" "node" {
+    count                   = "${var.num_nodes}"
+    ami                     = "${data.aws_ami.node_ami.id}"
+    instance_type           = "${var.node_type}"
+    key_name                = "${var.key_pair}"
+    vpc_security_group_ids  = ["${aws_vpc.demo_vpc.default_security_group_id}"]
+    subnet_id               = "${element(aws_subnet.demo_subnet.*.id, count.index)}"
+    tags {
+        Name                = "node-${count.index}"
+        tool                = "terraform"
+        demo                = "terraform"
+        area                = "compute"
+    }
+}

--- a/terraform/aws/vpc-all-azs/data.tf
+++ b/terraform/aws/vpc-all-azs/data.tf
@@ -1,0 +1,20 @@
+data "aws_availability_zones" "avail_zones" {
+    state                   = "available"
+}
+
+data "aws_ami" "node_ami" {
+    most_recent             = true
+    owners                  = ["099720109477"]
+    filter {
+        name                = "name"
+        values              = ["*ubuntu-xenial-16.04*"]
+    }
+    filter {
+        name                = "virtualization-type"
+        values              = ["hvm"]
+    }
+    filter {
+        name                = "root-device-type"
+        values              = ["ebs"]
+    }
+}

--- a/terraform/aws/vpc-all-azs/networking.tf
+++ b/terraform/aws/vpc-all-azs/networking.tf
@@ -1,0 +1,55 @@
+# Create a new VPC
+resource "aws_vpc" "demo_vpc" {
+    cidr_block              = "${var.assigned_cidr}"
+    enable_dns_hostnames    = "true"
+    enable_dns_support      = "true"
+    tags {
+        Name                = "multi_az_vpc"
+        tool                = "terraform"
+        demo                = "terraform"
+        area                = "networking"
+    }
+}
+
+# Modify default security group to allow inbound SSH
+resource "aws_security_group_rule" "allow_ssh" {
+    type                    = "ingress"
+    from_port               = 22
+    to_port                 = 22
+    protocol                = "tcp"
+    cidr_blocks             = ["0.0.0.0/0"]
+    security_group_id       = "${aws_vpc.demo_vpc.default_security_group_id}"
+}
+
+# Create a new Internet gateway
+resource "aws_internet_gateway" "demo_gw" {
+    vpc_id                  = "${aws_vpc.demo_vpc.id}"
+    tags {
+        Name                = "multi_az_gw"
+        tool                = "terraform"
+        demo                = "terraform"
+        area                = "networking"
+    }
+}
+
+# Add default route to VPC's main route table
+resource "aws_route" "default" {
+    route_table_id          = "${aws_vpc.demo_vpc.main_route_table_id}"
+    destination_cidr_block  = "0.0.0.0/0"
+    gateway_id              = "${aws_internet_gateway.demo_gw.id}"
+}
+
+# Create public subnet(s) in the new VPC
+resource "aws_subnet" "demo_subnet" {
+    count                   = "${length(data.aws_availability_zones.avail_zones.names)}"
+    vpc_id                  = "${aws_vpc.demo_vpc.id}"
+    cidr_block              = "${cidrsubnet(var.assigned_cidr, 8, count.index)}"
+    availability_zone       = "${element(data.aws_availability_zones.avail_zones.names, count.index)}"
+    map_public_ip_on_launch = "true"
+    tags {
+        Name                = "demo_subnet_${count.index}"
+        tool                = "terraform"
+        demo                = "terraform"
+        area                = "networking"
+    }
+}

--- a/terraform/aws/vpc-all-azs/provider.tf
+++ b/terraform/aws/vpc-all-azs/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region                  = "${var.user_region}"
+}

--- a/terraform/aws/vpc-all-azs/variables.tf
+++ b/terraform/aws/vpc-all-azs/variables.tf
@@ -1,0 +1,24 @@
+variable "user_region" {
+    type                    = "string"
+    description             = "AWS region to use for new resources"
+}
+
+variable "assigned_cidr" {
+    type                    = "string"
+    description             = "CIDR block to use for VPC and subnets"
+}
+
+variable "node_type" {
+    type                    = "string"
+    description             = "Type of instance to launch (such as t2.micro)"
+}
+
+variable "key_pair" {
+    type                    = "string"
+    description             = "SSH keypair to inject into launched instances"
+}
+
+variable "num_nodes" {
+    type                    = "string"
+    description             = "Number of nodes to launch"
+}


### PR DESCRIPTION
The purpose of this environment is to show how to determine the number of AZs within a region, then use that information to create a subnet in each region and launch an instance in each subnet.

The technique demonstrated here can be leveraged for other (more useful) purposes, such as spreading cluster members across subnets for higher availability.