### PR TITLE
Add environment leveraging Auto Scaling Groups

### DIFF
--- a/terraform/aws/ic-module-asg/README.md
+++ b/terraform/aws/ic-module-asg/README.md
@@ -1,0 +1,37 @@
+# "Instance Cluster" Module with Auto Scaling Group
+
+These files provide an example of a pair of modules that can be used to create "instance clusters" (groups of clusters serving a common function/role) using an Auto Scaling Group.
+
+## Contents
+
+* **data.tf**: This Terraform configuration file provides information to Terraform on which AWS AMIs to use.
+
+* **main.tf**: This Terraform configuration calls separate modules to create some VPCs and launch groups of instances ("instance clusters") in the VPCs.
+
+* **modules**: This directory contains two Terraform modules ("vpc" and "ic-asg"); these are called by `main.tf`.
+
+* **provider.tf**: This Terraform configuration files configures the AWS provider.
+
+* **README.md**: The file you're currently reading.
+
+* **variables.tf**: This Terraform configuration file specifies variables that Terraform will need in order to create the desired AWS infrastructure.
+
+## Instructions
+
+These instructions assume that you have an AWS account, that Terraform is installed and working correctly, and that you've appropriately supplied the necessary AWS credentials to Terraform. (If the AWS CLI works, then Terraform will be able to use the same credentials.)
+
+1. Place the files from the `terraform/aws/ic-module-asg` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the `terraform/aws/ic-module-asg` folder.
+
+2. Create a file named `terraform.tfvars` and populate it with the name of the AWS keypair you'd like to use for the instances, the AWS region to use, and the type of the instances (such as "t2.micro"). Refer to [this URL](https://www.terraform.io/intro/getting-started/variables.html) for specific details on the syntax of this file. You can refer to the contents of `variables.tf` for the names of the variables that need to be defined.
+
+3. Run `terraform init` to pull in the modules.
+
+4. Run `terraform plan` to have Terraform examine the current infrastructure and determine what changes are necessary to realize the desired configuration.
+
+5. Run `terraform apply` to have Terraform make the changes necessary to realize the desired configuration (by creating/modifying/deleting infrastructure).
+
+Enjoy!
+
+## License
+
+This content is licensed under the MIT License.

--- a/terraform/aws/ic-module-asg/data.tf
+++ b/terraform/aws/ic-module-asg/data.tf
@@ -1,0 +1,16 @@
+data "aws_ami" "node_ami" {
+    most_recent             = true
+    owners                  = ["099720109477"]
+    filter {
+        name                = "name"
+        values              = ["*ubuntu-xenial-16.04*"]
+    }
+    filter {
+        name                = "virtualization-type"
+        values              = ["hvm"]
+    }
+    filter {
+        name                = "root-device-type"
+        values              = ["ebs"]
+    }
+}

--- a/terraform/aws/ic-module-asg/main.tf
+++ b/terraform/aws/ic-module-asg/main.tf
@@ -1,0 +1,23 @@
+module "vpc20" {
+    source                  = "./modules/vpc"
+
+    name                    = "etcd"
+    vpc_cidr_block          = "10.20.0.0/16"
+    vpc_dns_hostnames       = "true"
+    vpc_dns_support         = "true"
+    subnet_map_pub_ip       = "true"    
+}
+
+module "etcd" {
+    source                  = "./modules/ic-asg"
+
+    name                    = "etcd"
+    ami                     = "${data.aws_ami.node_ami.id}"
+    type                    = "${var.node_type}"
+    assign_pub_ip           = true
+    ssh_key                 = "${var.key_pair}"
+    min_size                = 3
+    max_size                = 5
+    subnet_list             = ["${module.vpc20.subnet_id}"]
+    sec_group_list          = ["${module.vpc20.default_sg_id}"]
+}

--- a/terraform/aws/ic-module-asg/modules/ic-asg/main.tf
+++ b/terraform/aws/ic-module-asg/modules/ic-asg/main.tf
@@ -1,0 +1,27 @@
+# Create a launch configuration for the instance cluster
+resource "aws_launch_configuration" "lc" {
+    name                        = "${var.name}-lc"
+    associate_public_ip_address = "${var.assign_pub_ip}"
+    image_id                    = "${var.ami}"
+    instance_type               = "${var.type}"
+    key_name                    = "${var.ssh_key}"
+    security_groups             = ["${var.sec_group_list}"]
+
+    lifecycle {
+        create_before_destroy   = true
+    }
+}
+
+# Create an Auto Scaling group for the instance cluster
+resource "aws_autoscaling_group" "asg" {
+    name                        = "${var.name}-asg"
+    min_size                    = "${var.min_size}"
+    max_size                    = "${var.max_size}"
+    desired_capacity            = "${var.min_size}"
+    vpc_zone_identifier         = ["${var.subnet_list}"]
+    launch_configuration        = "${aws_launch_configuration.lc.name}"
+
+    lifecycle {
+        create_before_destroy   = true
+    }
+}

--- a/terraform/aws/ic-module-asg/modules/ic-asg/variables.tf
+++ b/terraform/aws/ic-module-asg/modules/ic-asg/variables.tf
@@ -1,0 +1,44 @@
+variable "name" {
+    type                    = "string"
+    description             = "Name to use for instances in this instance cluster"
+}
+
+variable "ami" {
+    type                    = "string"
+    description             = "AMI to use for instances in this instance cluster"
+}
+
+variable "type" {
+    type                    = "string"
+    description             = "Type to use for instances in this instance cluster"
+}
+
+variable "ssh_key" {
+    type                    = "string"
+    description             = "SSH key to inject into instances in this instance cluster"
+}
+
+variable "assign_pub_ip" {
+    type                    = "string"
+    description             = "True/False to assign a public IP address"
+}
+
+variable "sec_group_list" {
+    type                    = "list"
+    description             = "List of security group IDs for instances to use"
+}
+
+variable "min_size" {
+    type                    = "string"
+    description             = "Minimum number of instances in this instance cluster"
+}
+
+variable "max_size" {
+    type                    = "string"
+    description             = "Maximum number of instances in this instance cluster"
+}
+
+variable "subnet_list" {
+    type                    = "list"
+    description             = "List of subnets where instances should be launched"
+}

--- a/terraform/aws/ic-module-asg/modules/vpc/data.tf
+++ b/terraform/aws/ic-module-asg/modules/vpc/data.tf
@@ -1,0 +1,3 @@
+data "aws_availability_zones" "az_list" {
+    state                   = "available"
+}

--- a/terraform/aws/ic-module-asg/modules/vpc/main.tf
+++ b/terraform/aws/ic-module-asg/modules/vpc/main.tf
@@ -1,0 +1,52 @@
+# Create a new VPC
+resource "aws_vpc" "vpc" {
+    cidr_block              = "${var.vpc_cidr_block}"
+    enable_dns_hostnames    = "${var.vpc_dns_hostnames}"
+    enable_dns_support      = "${var.vpc_dns_support}"
+
+    tags {
+        Name                = "${var.name}_vpc"
+        tool                = "terraform"
+    }
+}
+
+# Modify default VPC security group to allow inbound SSH
+resource "aws_security_group_rule" "allow_ssh" {
+    type                    = "ingress"
+    from_port               = 22
+    to_port                 = 22
+    protocol                = "tcp"
+    cidr_blocks             = ["0.0.0.0/0"]
+    security_group_id       = "${aws_vpc.vpc.default_security_group_id}"
+}
+
+# Create a new Internet gateway
+resource "aws_internet_gateway" "gateway" {
+    vpc_id                  = "${aws_vpc.vpc.id}"
+
+    tags {
+        Name                = "${var.name}_igw"
+        tool                = "terraform"
+    }
+}
+
+# Add default route to VPC's main route table
+resource "aws_route" "default_route" {
+    route_table_id          = "${aws_vpc.vpc.main_route_table_id}"
+    destination_cidr_block  = "0.0.0.0/0"
+    gateway_id              = "${aws_internet_gateway.gateway.id}"
+}
+
+# Create a public subnet in the new VPC
+resource "aws_subnet" "subnet" {
+    count                   = "${length(data.aws_availability_zones.az_list.names)}"
+    vpc_id                  = "${aws_vpc.vpc.id}"
+    cidr_block              = "${cidrsubnet(var.vpc_cidr_block, 4, count.index)}"
+    availability_zone       = "${element(data.aws_availability_zones.az_list.names, count.index)}"
+    map_public_ip_on_launch = "${var.subnet_map_pub_ip}"
+
+    tags {
+        Name                = "${var.name}_subnet_${count.index}"
+        tool                = "terraform"
+    }
+}

--- a/terraform/aws/ic-module-asg/modules/vpc/output.tf
+++ b/terraform/aws/ic-module-asg/modules/vpc/output.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+    value                   = "${aws_vpc.vpc.id}"
+}
+
+output "subnet_id" {
+    value                   = "${aws_subnet.subnet.*.id}"
+}
+
+output "subnet_az" {
+    value                   = "${aws_subnet.subnet.*.availability_zone}"
+}
+
+output "default_sg_id" {
+    value                   = "${aws_vpc.vpc.default_security_group_id}"
+}

--- a/terraform/aws/ic-module-asg/modules/vpc/variables.tf
+++ b/terraform/aws/ic-module-asg/modules/vpc/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+    type                    = "string"
+    description             = "Name prefix to use for networking resources"
+}
+
+variable "vpc_cidr_block" {
+    type                    = "string"
+    description             = "CIDR block to use for new VPC"
+}
+
+variable "vpc_dns_hostnames" {
+    type                    = "string"
+    description             = "True/False to enable DNS hostnames in new VPC"
+}
+
+variable "vpc_dns_support" {
+    type                    = "string"
+    description             = "True/False to enable DNS support in new VPC"
+}
+
+variable "subnet_map_pub_ip" {
+    type                    = "string"
+    description             = "True/False to map public IP addresses on launch"
+}

--- a/terraform/aws/ic-module-asg/provider.tf
+++ b/terraform/aws/ic-module-asg/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region                  = "${var.user_region}"
+}

--- a/terraform/aws/ic-module-asg/variables.tf
+++ b/terraform/aws/ic-module-asg/variables.tf
@@ -1,0 +1,15 @@
+variable "user_region" {
+    type                    = "string"
+    description             = "AWS region to use for all resources"
+}
+
+variable "node_type" {
+    type                    = "string"
+    description             = "Type of instance to use"
+    default                 = "t2.micro"
+}
+
+variable "key_pair" {
+    type                    = "string"
+    description             = "SSH keypair to use for accessing instances"
+}


### PR DESCRIPTION
This new environment uses Terraform modules to create a new VPC and new subnets (across all availability zones in that region), and then uses launch configurations/Auto Scaling Groups to create "instance clusters" (groups of instances used for the same purpose/role).