### PR TITLE
Add generic environment for Fedora 26 Atomic Host

### DIFF
--- a/fedora-atomic/26-atomic-generic/README.md
+++ b/fedora-atomic/26-atomic-generic/README.md
@@ -1,0 +1,25 @@
+# Generic Fedora 26 Atomic Host VM
+
+These files were created to allow users to use Vagrant ([http://www.vagrantup.com](http://www.vagrantup.com)) to quickly and easily spin up an environment running Fedora 26 Atomic Host. This configuration was tested with VirtualBox and Libvirt (no VMware-compatible Fedora Atomic Host box was available).
+
+**NOTE:** This is just a generic VM environment. I'm including it here for the sake of completeness and because it can/will serve as a basis for other environments.
+
+## Contents
+
+* **machines.yml**: This YAML file contains a list of VM definitions and associated configuration data. It is referenced by `Vagrantfile` when Vagrant instantiates the VMs.
+
+* **README.md**: This file you're currently reading.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up the virtual machines. This file is fairly extensively commented to help explain what's happening. You should be able to use this file unchanged; all the VM configuration options are stored outside this file.
+
+## Instructions
+
+These instructions assume you've already installed your virtualization provider (VMware Fusion/Workstation or VirtualBox), Vagrant, and any necessary plugins (such as the Vagrant VMware plugin). Please refer to the documentation for those products for more information on installation or configuration.
+
+1. Use `vagrant box add` to add a Fedora Atomic Host base box to be used by this `Vagrantfile`. (This environment was tested using Fedora 26 Atomic Host.) You'll need to specify a box that provides support for the virtualization provider you're planning to use. The existing `machines.yml` file provides some suggested boxes.
+
+2. If you decide to use a box _other_ than one listed in `machines.yml`, edit `machines.yml` to specify the name of the box you added in step 1. In `machines.yml`, the "vmw" line is for a VMware-formatted box, the "vb" line is for the name of a VirtualBox-formatted box, and the "lv" line is for the name of a box that supports the Libvirt provider. Edit the appropriate line based on your virtualization provider and the name of the box you added in step 1.
+
+3. Run `vagrant up`, and when the VM is up use `vagrant ssh` to access the VM.
+
+Enjoy!

--- a/fedora-atomic/26-atomic-generic/Vagrantfile
+++ b/fedora-atomic/26-atomic-generic/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify minimum Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, RAM, IP addresses)
+# Edit machines.yml to change VM configuration details
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+
+    # Configure the VMs per details in machines.yml
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+
+      # Specify the hostname of the VM
+      srv.vm.hostname = machine['name']
+
+      # Specify the Vagrant box to use (use VMware box by default)
+      srv.vm.box = machine['box']['vmw']
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Iterate through networks as per settings in machines.yml
+      machine['nics'].each do |net|
+        if net['ip_addr'] == 'dhcp'
+          srv.vm.network net['type'], type: net['ip_addr']
+        else
+          srv.vm.network net['type'], ip: net['ip_addr']
+        end # if net['ip_addr']
+      end # machine['nics'].each
+
+      # Assign additional private network
+      #if machine['ip_addr'] != nil
+      #  srv.vm.network 'private_network', ip: machine['ip_addr']
+      #end # if machine['ip_addr']
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider 'vmware_fusion'
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['box']['vb']
+      end # srv.vm.provider 'virtualbox'
+
+      # Configure CPU & RAM per settings in machines.yml (Libvirt)
+      srv.vm.provider 'libvirt' do |lv,override|
+        lv.memory = machine['ram']
+        lv.cpus = machine['vcpu']
+        override.vm.box = machine['box']['lv']
+        if machine['nested'] == true
+          lv.nested = true
+        end # if machine['nested']
+      end # srv.vm.provider 'libvirt'
+    end # config.vm.define
+  end # machines.each
+end # Vagrant.configure

--- a/fedora-atomic/26-atomic-generic/machines.yml
+++ b/fedora-atomic/26-atomic-generic/machines.yml
@@ -1,0 +1,12 @@
+---
+- box:
+    vmw: "bento/debian-9.2"
+    vb: "fedora/26-atomic-host"
+    lv: "fedora/26-atomic-host"
+  name: "atomic-01"
+  nested: false
+  nics:
+  - type: "private_network"
+    ip_addr: "dhcp"
+  ram: "1024"
+  vcpu: "1"


### PR DESCRIPTION
This environment can serve as a basis for more complex environments in the future.